### PR TITLE
Remove cert timezone workaround

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,5 +45,3 @@ $ bkr workflow-tomorrow --reserve --distro RHEL-9.0.0-20210914.0 --hostrequire '
 ```
 
 Test scenario can be executed in a similar fashion with one change. Instead of /keylime/install/configure_tpm_emulator/ you should run /keylime/install/configure_kernel_ima_module/ test. This test reboots the system so once it comes up again you should run the test once more to complete the setup.
-
-Also, be aware that there is a bug in keylime when generating TLS certificates. NBDE test systems are configured to CET/CEST timezone which manifests the issue. A fix (?) is being applied in install_upstream_keylime/test.sh but even with this change test scenario doesn't work. This problem is currently being investigated.

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -23,8 +23,6 @@ _EOF'
         rlRun "yum -y install git-core python3-pip python3-pyyaml python3-tornado python3-simplejson python3-requests python3-sqlalchemy python3-alembic python3-packaging python3-psutil python3-gnupg python3-cryptography libselinux-python3 procps-ng tpm2-abrmd tpm2-tss tpm2-tools python3-zmq cfssl patch"
         rlRun "rm -rf keylime && git clone https://github.com/keylime/keylime.git"
         pushd keylime
-        # apply fix for the timezone bug https://github.com/keylime/keylime/issues/759
-        rlRun "sed -i 's/today = datetime.datetime.today()/today = datetime.datetime.now(datetime.timezone.utc)/' keylime/ca_impl_openssl.py"
         rlRun "python3 setup.py install"
         popd
     rlPhaseEnd


### PR DESCRIPTION
As the respective keylime issue has been fixed upstream already.