### PR TITLE
Add Library/sync and adjust multihost test for it

### DIFF
--- a/Library/sync/lib.sh
+++ b/Library/sync/lib.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: provides basic function for token manipulation
+#   Author: Karel Srot <ksrot@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2021 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   library-prefix = sync
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+true <<'=cut'
+=pod
+
+=head1 NAME
+
+keylime-tests/sync - provides synchronization capabilities for multi-host testing
+
+=head1 DESCRIPTION
+
+The library provides sync-set and sync-block commands and also sync-get systemd
+service. All these scripts are installed and service enabled and started during
+the library load.
+
+=cut
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Variables
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# we are using hardcoded paths so they are preserved due to reboots
+export __INTERNAL_syncStatusFile=/var/tmp/sync-status
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Initialization / Installation
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# double check nmap is installed (requires are not installed with direct library load)
+rpm -q nmap-ncat hostname &> /dev/null || yum -y install nmap-ncat hostname
+
+#   Create status file
+touch $__INTERNAL_syncStatusFile
+
+# install sync-set and sync-block scripts to /usr/local/bin
+which sync-set &> /dev/null || cp $syncLibraryDir/sync-set /usr/local/bin && chmod a+x /usr/local/bin/sync-set
+which sync-block &> /dev/null || cp $syncLibraryDir/sync-block /usr/local/bin && chmod a+x /usr/local/bin/sync-block
+
+# install and enable and start sync-get service
+if ! systemctl is-active sync-get; then
+    cp $syncLibraryDir/sync-get.service /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl --now enable sync-get &> /dev/null
+    sleep 1
+fi
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Verification
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   This is a verification callback which will be called by
+#   rlImport after sourcing the library to make sure everything is
+#   all right. It makes sense to perform a basic sanity test and
+#   check that all required packages are installed. The function
+#   should return 0 only when the library is ready to serve.
+
+syncLibraryLoaded() {
+    which sync-set &> /dev/null && which sync-block &> /dev/null && systemctl is-active sync-get &> /dev/null
+}
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Authors
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+true <<'=cut'
+=pod
+
+=head1 AUTHORS
+
+=over
+
+=item *
+
+Karel Srot <ksrot@redhat.com>
+
+=back
+
+=cut

--- a/Library/sync/main.fmf
+++ b/Library/sync/main.fmf
@@ -1,0 +1,16 @@
+summary: sync library
+description: 'beakerlib library providing synchronization capabilities for multi-host tests'
+contact: Karel Srot <ksrot@redhat.com>
+component: []
+test: ./runtest.sh
+framework: beakerlib
+require:
+- nmap-ncat
+- hostname
+- systemd
+duration: 5m
+enabled: true
+adjust:
+-   enabled: false
+    when: distro == rhel-4, rhel-5, rhel-6, rhel-7
+    continue: false

--- a/Library/sync/runtest.sh
+++ b/Library/sync/runtest.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: provides helper functions for keylime tests
+#   Author: Karel Srot <ksrot@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2021 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="keylime"
+PHASE=${PHASE:-Test}
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "rlImport ./sync"
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+    rlPhaseEnd
+
+    # Self test
+    if [[ "$PHASE" =~ "Test" ]]; then
+        rlPhaseStartTest "Test library import"
+            rlRun "sync-set READY"
+            rlAssertGrep "READY:.* $( hostname -i )" /var/tmp/sync-status -E
+            rlRun -s "sync-block -d READY $( hostname -i )"
+            rlAssertGrep "UNBLOCKED" $rlRun_LOG
+            rlServiceStart sync-get
+            rlRun -s "ncat --recv-only localhost 1918"
+            rlAssertGrep "READY:.* $( hostname -i )" $rlRun_LOG -E
+            rlServiceStop sync-get
+        rlPhaseEnd
+    fi
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm /var/tmp/sync-status"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/Library/sync/sync-block
+++ b/Library/sync/sync-block
@@ -1,0 +1,110 @@
+#!/bin/bash
+STATUS_FILE=/var/tmp/sync-status
+PORT=1918
+TMPFILE=$( mktemp )
+[ "$SYNC_DEBUG" == "1" -o "$SYNC_DEBUG" == "true" ] || SYNC_DEBUG=false
+
+function debug() {
+    $SYNC_DEBUG && echo -e $@
+}
+
+# enable debug mode?
+if [ "$1" == "-d" ]; then
+    SYNC_DEBUG=true
+    shift
+fi
+
+# for incorrect number parameters print help
+if [ -z "$1" -o -z "$2" -o "$1" == "-h" -o "$1" == "--help" ]; then
+    echo "Usage: $0 [-d] STATE HOST_IDENTIFIER"
+    echo "e.g. $0 TEST_READY foo.bar.com"
+    exit 1
+fi
+
+# get STATE
+# ${XTRA} is being added for compatibility purposes with Beaker/Restraing
+# also, ${XTRA} should be changed for each manual test run
+STATE="${XTRA}_$1"
+shift
+
+function is_blocked() {
+
+    BLOCKED=false
+    while [ -n "$1" ]; do
+
+        IDENTIFIER="$1"
+        debug "\nchecking STATE $STATE of IDENTIFIER $IDENTIFIER"
+
+        # when SYNC_PROVIDER not set, connect to the provided HOST_IDENTIFIER
+        if [ -n "$SYNC_PROVIDER" ]; then
+            PROVIDER="$SYNC_PROVIDER"
+        else
+            PROVIDER="$IDENTIFIER"
+        fi
+        debug "status PROVIDER $PROVIDER"
+
+        MY_FQDNS="$( hostname -A | sed -e 's/localhost\(.localdomain\)*//g' )"
+        MY_IPS="$( hostname -I )"
+        MY_IDENTIFIERS="$MY_FQDNS $MY_IPS"
+
+        # when I am the SYNC_PROVIDER read statuses locally
+        if echo " $MY_IDENTIFIERS " | egrep -q " $PROVIDER "; then
+            debug "reading statuses from local $STATUS_FILE"
+            cat $STATUS_FILE > $TMPFILE
+        else
+            # read the status file over the network
+            debug "reading statuses from $PROVIDER"
+            ncat --recv-only $PROVIDER $PORT 2> /dev/null > $TMPFILE
+        fi
+
+        if [ $? -eq 0 ]; then
+
+            $SYNC_DEBUG && echo "--- response ---" && cat $TMPFILE && echo "----------------"
+            # I am blocked if there is not a line with STATE for the given IDENTIFIER
+            egrep -q "^$STATE:" $TMPFILE || BLOCKED=true
+            egrep -q "^$STATE:.* $IDENTIFIER " $TMPFILE || BLOCKED=true
+            $BLOCKED && debug "$IDENTIFIER is blocked" || debug "$IDENTIFIER is not blocked"
+
+        else
+
+            # when getting status failed I am blocked
+            debug "getting status failed"
+            BLOCKED=true
+
+        fi
+
+        # when blocked, terminate the loop
+        if $BLOCKED; then
+            debug "$IDENTIFIER is blocked, terminating this round"
+            break
+        fi
+
+        # move to the next IDENTIFIER
+        shift
+
+    done
+
+    rm $TMPFILE
+    $BLOCKED && debug "\ndecision is BLOCKED" || debug "\ndecision is NOT BLOCKED"
+
+    if $BLOCKED; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+ROUND=1
+DELAYS="1 1 2 3 5 8 13 21 34 55"
+echo -n "Checking status - round $ROUND: "
+
+while is_blocked "$@"; do
+    echo "BLOCKED"
+    DELAY=${DELAYS%% *}  # current delay
+    DELAYS=${DELAYS#* }  # cut-off current delay for DELAYS list (except the last one)
+    sleep $DELAY
+    ROUND=$(( $ROUND+1 ))
+    echo -n "Checking status - round $ROUND: "
+done
+
+echo "UNBLOCKED"

--- a/Library/sync/sync-get.service
+++ b/Library/sync/sync-get.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=sync-get service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ncat -l -k -e '/usr/bin/cat /var/tmp/sync-status' --send-only 1918
+TimeoutStopSec=5
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+

--- a/Library/sync/sync-set
+++ b/Library/sync/sync-set
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# file for tracking sync states on this system (if used)
+STATUS_FILE=/var/tmp/sync-status
+[ "$SYNC_DEBUG" == "1" -o "$SYNC_DEBUG" == "true" ] || SYNC_DEBUG=false
+
+function debug() {
+    $SYNC_DEBUG && echo -e $@
+}
+
+# enable debug mode?
+if [ "$1" == "-d" ]; then
+    SYNC_DEBUG=true
+    shift
+fi
+
+# print help
+if [ -z "$1" -o "$1" == "-h" -o "$1" == "--help" ]; then
+    echo "Usage: $0 STATE [HOST_IDENTIFIER]"
+    echo "e.g. $0 TEST_READY foo.bar.com"
+    echo "     $0 TEST_READY foo.bar.com 10.0.2.35"
+    exit 1
+fi
+
+# save STATE
+# ${XTRA} is being added for compatibility purposes with Beaker/Restraing
+# also, ${XTRA} should be changed for each manual test run
+STATE="${XTRA}_$1"
+shift
+
+# save IDENTIFIERs
+IDENTIFIERS="$@"
+MY_FQDNS="$( hostname -A | sed -e 's/localhost\(.localdomain\)*//g' )"
+MY_IPS="$( hostname -I )"
+MY_IDENTIFIERS="$MY_FQDNS $MY_IPS"
+
+# use MY_IDENTIFIERS if IDENTIFIERS were not provided on cmdline
+if [ -z "$IDENTIFIERS" ]; then
+    IDENTIFIERS="$MY_IDENTIFIERS"
+fi
+
+# build a MESSAGE and remove redundant spaces
+MESSAGE=$( echo "$STATE: $IDENTIFIERS " | sed -r -e 's/[ ]+/ /g' )
+debug "MESSAGE='$MESSAGE'"
+
+# when SYNC_PROVIDER is not set or I am the SYNC_PROVIDER
+# and will store the message locally
+if [ -z "$SYNC_PROVIDER" ] || echo " $MY_IDENTIFIERS " | egrep -q " $SYNC_PROVIDER "; then
+
+    # check if the message hasn't been saved already
+    if grep -q "^$MESSAGE\$" $STATUS_FILE 2> /dev/null; then
+        debug "message has been already saved"
+    else
+        echo "$MESSAGE" >> $STATUS_FILE
+        debug "message saved to $STATUS_FILE"
+    fi
+ 
+else
+
+    # remove SYNC_PROVIDER is not yet implemented
+    :
+
+fi
+
+exit 0


### PR DESCRIPTION
Implements Library/sync so that multihost tests can be run outside of Beaker/Restraint environment.