### PR TITLE
4 host scenario with revocation

### DIFF
--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -1,15 +1,16 @@
 summary: Tests basic keylime attestation scenario on multiple hosts
 contact: Karel Srot <ksrot@redhat.com>
 component:
-- keylime
+  - keylime
 test: ./test.sh
 framework: beakerlib
 tag:
-- multihost
+  - multihost
 require:
-- library(openssl/certgen)
-- yum
-- bind-utils
+  - library(openssl/certgen)
+  - yum
+  - bind-utils
+  - expect
 duration: 10m
 enabled: true
 extra-nitrate: TC#0611986

--- a/Multihost/basic-attestation/payload/action_list
+++ b/Multihost/basic-attestation/payload/action_list
@@ -1,0 +1,1 @@
+local_action_modify_payload

--- a/Multihost/basic-attestation/payload/autorun.sh
+++ b/Multihost/basic-attestation/payload/autorun.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp test_payload_file /var/tmp/

--- a/Multihost/basic-attestation/payload/local_action_modify_payload.py
+++ b/Multihost/basic-attestation/payload/local_action_modify_payload.py
@@ -1,0 +1,21 @@
+import os
+import ast
+import keylime.secure_mount as secure_mount
+from keylime import keylime_logging
+from keylime import ca_util
+from keylime import config
+
+logger = keylime_logging.init_logging("local_action_rm_ssh")
+
+async def execute(event):
+    if event.get("type") != "revocation":
+        return
+
+    # load up my own cert
+    event_uuid = event.get("agent_id", "my")
+    my_uuid = config.get('cloud_agent', 'agent_uuid')
+    logger.info("A node in the network has been compromised: %s", event["ip"])
+    logger.info("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))
+    # is this revocation meant for me?
+    if my_uuid == event_uuid:
+        os.remove("/var/tmp/test_payload_file")

--- a/Multihost/basic-attestation/payload/test_payload_file
+++ b/Multihost/basic-attestation/payload/test_payload_file
@@ -1,0 +1,1 @@
+test payload


### PR DESCRIPTION
Adds revocation scenario to a multi-host test and also option to use 4th system as another agent.
In future, we may want to move tenant to a separate system.