### PR TITLE
Enable testing both distribution and upstream keylime

### DIFF
--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -14,6 +14,11 @@ require:
   - tpm2-abrmd
 recommend:
   - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
 duration: 10m
 enabled: true
 extra-nitrate: TC#0611986

--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -11,6 +11,9 @@ require:
   - yum
   - bind-utils
   - expect
+  - tpm2-abrmd
+recommend:
+  - keylime
 duration: 10m
 enabled: true
 extra-nitrate: TC#0611986

--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -455,6 +455,7 @@ rlJournalStart
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
         rlRun 'rlImport "./sync"' || rlDie "cannot import keylime-tests/sync library"
         rlRun 'rlImport "openssl/certgen"' || rlDie "cannot import openssl/certgen library"
+        rlAssertRpm keylime
         # backup files
         limeBackupConfig
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,9 +15,10 @@ $ git clone https://github.com/RedHat-SP-Security/keylime-tests.git
 $ cd keylime-tests
 ```
 
-With `tmt` you can easily run all test plans. Currently, there is one
-test plan in the `plans/keylime-tests-github-ci` file.
-You may want to update it to run only the required tasks.
+With `tmt` you can easily run all test plans. Currently, there are two
+test plans in the `plans/` directory. These are being used for CI testing
+using Packit service. When running tests yourself you may want to update
+them (or even remove) in order to run only the required tasks.
 
 ```
 $ tmt run -vvv prepare discover provision -h local execute
@@ -53,7 +54,7 @@ First you need to install `tmt` tool and clone tests repository.
 $ git clone https://github.com/RedHat-SP-Security/keylime-tests.git
 ```
 
-Then you can run a test plan e.g. on F35 system.
+Then you can run all test plans e.g. on F35 system.
 
 ```
 $ cd keylime-tests
@@ -81,6 +82,24 @@ is properly detected and prepare step adjustment enabling EPEL gets run.
 ```
 $ tmt -c distro=centos-stream-9 run -vvv prepare discover provision -h virtual -i centos-stream-9 -c system execute finish
 ```
+
+### Running tests from specific test plan or specific tests
+
+In case you do not want to run tests from all plans the easiest option would be tell `tmt` to run only specific tests.
+
+```
+$ tmt run -vvv prepare discover -h fmf -t 'configure_tpm_emulator' -t 'install_upstream_keylime' -t 'functional/basic-attestation' provision -h virtual -i Fedora-35 -c system -i 1MT-Fedora-35 execute finish
+```
+This will run only tests whose names contains provided regexp patterns.
+
+You can also tell `tmt` to run only tests from a particular test plan. E.g.
+
+```
+$ tmt run -vvv plan --name upstream prepare discover -h fmf provision -h virtual -i Fedora-35 -c system -i 1MT-Fedora-35 execute finish
+```
+will execute only tests from test plans whose name contains "upstream".
+
+Finally, you can (locally) edit or remove test plans in the `plan/` directory in order to get to a desired state.
 
 ### Running multi-host tests
 

--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -10,6 +10,11 @@ require:
 - tpm2-abrmd
 recommend:
 - keylime
+- keylime-verifier
+- keylime-registrar
+- python3-keylime-agent
+- keylime-tenant
+- keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0611725

--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -7,6 +7,9 @@ framework: beakerlib
 require:
 - yum
 - expect
+- tpm2-abrmd
+recommend:
+- keylime
 duration: 15m
 enabled: true
 extra-nitrate: TC#0611725

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -7,6 +7,7 @@ rlJournalStart
 
     rlPhaseStartSetup "Do the keylime setup"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
         limeBackupConfig
         # update /etc/keylime.conf
         rlRun "limeUpdateConf tenant require_ek_cert False"

--- a/functional/db-mariadb-sanity-on-localhost/main.fmf
+++ b/functional/db-mariadb-sanity-on-localhost/main.fmf
@@ -10,5 +10,12 @@ require:
   - python3-PyMySQL
   - tpm2-abrmd
   - tpm2-tools
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
 duration: 5m
 enabled: true

--- a/functional/db-mysql-sanity-on-localhost/main.fmf
+++ b/functional/db-mysql-sanity-on-localhost/main.fmf
@@ -13,5 +13,12 @@ require:
   - tpm2-abrmd
   - tpm2-tools
 #  - mysql-sever  # not used due to conflict with mariadb
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
 duration: 15m
 enabled: true

--- a/functional/db-postgresql-sanity-on-localhost/main.fmf
+++ b/functional/db-postgresql-sanity-on-localhost/main.fmf
@@ -11,5 +11,12 @@ require:
   - python3-psycopg2
   - tpm2-abrmd
   - tpm2-tools
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
 duration: 5m
 enabled: true

--- a/functional/keylime_tenant-commands-on-localhost/main.fmf
+++ b/functional/keylime_tenant-commands-on-localhost/main.fmf
@@ -6,5 +6,8 @@ test: ./test.sh
 framework: beakerlib
 require:
 - yum
+- tpm2-abrmd
+recommend:
+- keylime
 duration: 15m
 enabled: true

--- a/functional/keylime_tenant-commands-on-localhost/main.fmf
+++ b/functional/keylime_tenant-commands-on-localhost/main.fmf
@@ -9,5 +9,10 @@ require:
 - tpm2-abrmd
 recommend:
 - keylime
+- keylime-verifier
+- keylime-registrar
+- python3-keylime-agent
+- keylime-tenant
+- keylime-tools
 duration: 15m
 enabled: true

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -7,6 +7,7 @@ rlJournalStart
 
     rlPhaseStartSetup "Do the keylime setup"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
         limeBackupConfig
         # update /etc/keylime.conf
         rlRun "limeUpdateConf tenant require_ek_cert False"

--- a/functional/tpm_policy-sanity-on-localhost/main.fmf
+++ b/functional/tpm_policy-sanity-on-localhost/main.fmf
@@ -8,6 +8,8 @@ require:
   - yum
   - tpm2-abrmd
   - tpm2-tools
+recommend:
+  - keylime
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612863

--- a/functional/tpm_policy-sanity-on-localhost/main.fmf
+++ b/functional/tpm_policy-sanity-on-localhost/main.fmf
@@ -10,6 +10,11 @@ require:
   - tpm2-tools
 recommend:
   - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612863

--- a/functional/tpm_policy-sanity-on-localhost/test.sh
+++ b/functional/tpm_policy-sanity-on-localhost/test.sh
@@ -8,6 +8,7 @@ rlJournalStart
     rlPhaseStartSetup "Do the keylime setup"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
         limeBackupConfig
+        rlAssertRpm keylime
         # if TPM emulator is present
         if limeTPMEmulated; then
             # start tpm emulator

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -1,0 +1,15 @@
+summary:
+  Tests used by Packit/TFT CI on Github to test distribution keylime
+adjust:
+    enabled: false
+    when: distro = centos-stream
+discover:
+  how: fmf
+  test: 
+   - /setup/configure_tpm_emulator
+   - /setup/enable_keylime_coverage
+   - "/functional/.*"
+   - /setup/generate_coverage_report
+
+execute:
+    how: tmt

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -10,9 +10,9 @@ discover:
   how: fmf
   test: 
    - /setup/configure_tpm_emulator
-   - /setup/enable_keylime_coverage
+#   - /setup/enable_keylime_coverage
    - "/functional/.*"
-   - /setup/generate_coverage_report
+#   - /setup/generate_coverage_report
 
 execute:
     how: tmt

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -3,6 +3,9 @@ summary:
 adjust:
     enabled: false
     when: distro = centos-stream
+prepare:
+  how: shell
+  script: dnf config-manager --set-enabled updates-testing updates-testing-modular
 discover:
   how: fmf
   test: 

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -5,7 +5,11 @@ adjust:
     when: distro = centos-stream
 prepare:
   how: shell
-  script: dnf config-manager --set-enabled updates-testing updates-testing-modular
+  script:
+   - rm -f /etc/yum.repos.d/tag-repository.repo
+   - dnf config-manager --set-enabled updates-testing updates-testing-modular
+   - dnf makecache
+   - dnf -y update
 discover:
   how: fmf
   test: 

--- a/plans/upstream-keylime-tests-github-ci.fmf
+++ b/plans/upstream-keylime-tests-github-ci.fmf
@@ -1,5 +1,5 @@
 summary:
-  Tests used by Packit/TFT CI on Github
+  Tests used by Packit/TFT CI on Github to test upstream keylime
 adjust:
   - when: distro == centos-stream-9
     prepare+:
@@ -14,8 +14,6 @@ discover:
    - /setup/install_upstream_keylime
    - /setup/enable_keylime_coverage
    - "/functional/.*"
-#   - /setup/install_upstream_rust_keylime
-#   - "/functional/.*"
    - /setup/generate_coverage_report
 
 execute:

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -78,6 +78,14 @@ User=tss
 [Install]
 WantedBy=multi-user.target
 _EOF"
+        # also add drop-in update for eventual keylime_agent unit file
+        rlRun "mkdir /etc/systemd/system/keylime_agent.service.d"
+        rlRun 'cat > /etc/systemd/system/keylime_agent.service.d/10-tcti.conf <<_EOF
+[Service]
+Environment="TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd"
+_EOF'
+        rlRun "systemctl daemon-reload"
+
         if [ "${TPM_EMULATOR}" = "swtpm" ]; then
             # now we need to build custom selinux module making swtpm_t a permissive domain
             # since the policy module shipped with swtpm package doesn't seem to work
@@ -88,9 +96,8 @@ _EOF"
                 rlRun "semodule -i swtpm_permissive.pp"
             fi
         fi
-        rlRun "setsebool -P tabrmd_connect_all_unreserved on"
         # allow tpm2-abrmd to connect to swtpm port
-        rlRun "systemctl daemon-reload"
+        rlRun "setsebool -P tabrmd_connect_all_unreserved on"
     rlPhaseEnd
 
     rlPhaseStartSetup "Start TPM emulator"

--- a/setup/install_upstream_keylime/keylime.spec
+++ b/setup/install_upstream_keylime/keylime.spec
@@ -1,0 +1,21 @@
+Name:		keylime
+Version:	99
+Release:	1
+Summary:	Dummy package preventing keylime RPM installation
+License:	GPLv2+	
+BuildArch:  noarch
+
+%description
+Dummy package that prevents replacing installed keylime bits with keylime RPM
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Fri Jan 28 2022 Karel Srot <ksrot@redhat.com> 99-1
+- Initial version

--- a/setup/install_upstream_keylime/main.fmf
+++ b/setup/install_upstream_keylime/main.fmf
@@ -7,6 +7,8 @@ framework: beakerlib
 require:
  - git
  - yum
+ - gawk
+ - rpm-build
 duration: 5m
 enabled: true
 extra-nitrate: TC#0611727

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -5,6 +5,8 @@
 rlJournalStart
 
     rlPhaseStartSetup "Install keylime and its dependencies"
+        # remove all install keylime packages
+        rlRun "yum remove -y python3-keylime\* keylime\*"
         # build and install keylime-99 dummy RPM
         rlRun -s "rpmbuild -bb keylime.spec"
         RPMPKG=$( awk '/Wrote:/ { print $2 }' $rlRun_LOG )

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -5,6 +5,11 @@
 rlJournalStart
 
     rlPhaseStartSetup "Install keylime and its dependencies"
+        # build and install keylime-99 dummy RPM
+        rlRun -s "rpmbuild -bb keylime.spec"
+        RPMPKG=$( awk '/Wrote:/ { print $2 }' $rlRun_LOG )
+        # replace installed keylime with our newly built dummy package
+        rlRun "rpm -Uvh $RPMPKG"
         # for RHEL and CentOS Stream configure Sergio's copr repo providing necessary dependencies
         if rlIsFedora; then
             FEDORA_EXTRA_PKGS="python3-lark-parser"


### PR DESCRIPTION
We have keylime listed in `recommend` instead of `require` in test `main.fmf` because on CentOS Stream it is not yet available and we do not want the provision step to fail. Eventually, keylime is later installed (or replaced) by `/setup/install_upstream_keylime` test.