### PR TITLE
Lower rlWaitForSocket timeout to 30 seconds

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -590,7 +590,7 @@ limeWaitForVerifier() {
 
     local PORT
     [ -n "$1" ] && PORT=$1 || PORT=8881
-    rlWaitForSocket $PORT -d 0.1
+    rlWaitForSocket $PORT -d 0.5 -t 30
 }
 
 true <<'=cut'
@@ -618,7 +618,7 @@ limeWaitForRegistrar() {
 
     local PORT
     [ -n "$1" ] && PORT=$1 || PORT=8891
-    rlWaitForSocket $PORT -d 0.1
+    rlWaitForSocket $PORT -d 0.5 -t 30
 
 }
 
@@ -647,7 +647,7 @@ limeWaitForTPMEmulator() {
 
     local PORT
     [ -n "$1" ] && PORT=$1 || PORT=2322
-    rlWaitForSocket $PORT -d 0.1
+    rlWaitForSocket $PORT -d 0.5 -t 30
 
 }
 


### PR DESCRIPTION
Failing tests should fail faster thanks to rlWaitForSocket timeout being reduced from 120 secs to 30 secs.