### PR TITLE
Move rlImport under rlPhaseStart to avoid errors

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -533,9 +533,9 @@ limeTPMEmulator() {
     # We use swtpm by default, unless in EL8 -- since tpm2-tss shipped
     # there does not support it, we will use ibmswtpm2 instead.
     _tpm_emulator=swtpm
-    _platform_id="$(awk -F= '$1=="PLATFORM_ID" { print $2 ;}' \
-                    /etc/os-release | tr -d '"' | cut -d':' -f2)" ||:
-    [ "${_platform_id}" = "el8" ] && _tpm_emulator=ibmswtpm2
+    if rlIsRHEL 8 || rlIsCentOS 8; then
+        _tpm_emulator=ibmswtpm2
+    fi
     echo "${_tpm_emulator}"
 }
 

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -11,20 +11,20 @@ if [ "$RUNNING" != "0" -a "$RUNNING" != "1" ]; then
     systemctl is-active --quiet tpm2-abrmd && RUNNING=1 || RUNNING=0
 fi
 
-# We use ibmswtpm2 for EL8 and swtpm for the other platforms.
-rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
-TPM_EMULATOR=$(limeTPMEmulator)
-
 # Packages list based on the TPM emulator.
+# We use ibmswtpm2 for EL8 and swtpm for the other platforms.
 TPM_PKGS_SWTPM="swtpm swtpm-tools"
 TPM_PKGS_IBMSWTPM="ibmswtpm2"
-
-TPM_PKGS="${TPM_PKGS_SWTPM}"
-[ "${TPM_EMULATOR}" = "ibmswtpm2" ] && TPM_PKGS="${TPM_PKGS_IBMSWTPM}"
 
 rlJournalStart
 
     rlPhaseStartSetup "Install TPM emulator"
+
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+
+        TPM_EMULATOR="$(limeTPMEmulator)"
+        [ "${TPM_EMULATOR}" == "ibmswtpm2" ] && TPM_PKGS="${TPM_PKGS_IBMSWTPM}" || TPM_PKGS="${TPM_PKGS_SWTPM}"
+
         # for RHEL and CentOS Stream configure Sergio's copr repo providing
         # necessary dependencies.
         if rlIsRHEL 8 || rlIsCentOS 8; then


### PR DESCRIPTION
With rlRun and rlImport outside the beakerlib phase errors like
```
:: [ 16:47:49 ] :: [  BEGIN   ] :: Running 'rlImport "./test-helpers"'
/usr/share/beakerlib/logging.sh: line 133: : No such file or directory
/usr/share/beakerlib/logging.sh: line 134: : No such file or directory
```
are present in the test log.