### PR TITLE
Enable powertools repo on CentOS Stream 8

### DIFF
--- a/plans/upstream-keylime-tests-github-ci.fmf
+++ b/plans/upstream-keylime-tests-github-ci.fmf
@@ -6,7 +6,9 @@ adjust:
        script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
   - when: distro == centos-stream-8
     prepare+:
-       script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+       script:
+         - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+         - yum config-manager --set-enabled powertools
 discover:
   how: fmf
   test: 


### PR DESCRIPTION
python3-packaging package is available in powertools repo on CentOS Stream 8.