### PR TITLE
Implement changes in limeWaitFor functions

### DIFF
--- a/functional/db-mariadb-sanity-on-localhost/test.sh
+++ b/functional/db-mariadb-sanity-on-localhost/test.sh
@@ -2,6 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
 rlJournalStart
 
@@ -56,19 +57,18 @@ rlJournalStart
         rlRun "limeWaitForVerifier"
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
-	rlRun -s "echo 'show databases;' | mysql -u root"
-	rlAssertGrep "verifierdb" $rlRun_LOG
-	rlAssertGrep "registrardb" $rlRun_LOG
+        rlRun -s "echo 'show databases;' | mysql -u root"
+        rlAssertGrep "verifierdb" $rlRun_LOG
+        rlAssertGrep "registrardb" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Test adding keylime tenant"
         rlRun "limeStartAgent"
-        sleep 5
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         # create allowlist and excludelist
         limeCreateTestLists
-        AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
         rlRun "lime_keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f /etc/hostname -c add"
-        rlRun "limeWaitForTenantStatus $AGENT_ID 'Get Quote'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
         rlRun -s "lime_keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
     rlPhaseEnd

--- a/functional/db-mysql-sanity-on-localhost/test.sh
+++ b/functional/db-mysql-sanity-on-localhost/test.sh
@@ -2,6 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
 rlJournalStart
 
@@ -17,8 +18,8 @@ rlJournalStart
         rlRun "rm -rf /var/lib/mysql/*"
  
         # check if mariadb is installed and replace it with mysql-server
-	PKGS=$( rpm -qa | grep 'mariadb' | xargs echo )
-	if [ -n "$PKGS" ]; then
+        PKGS=$( rpm -qa | grep 'mariadb' | xargs echo )
+        if [ -n "$PKGS" ]; then
             rlRun "yum -y remove $PKGS"
         fi
         rlRun "yum -y install mysql-server"
@@ -67,19 +68,18 @@ rlJournalStart
         rlRun "limeWaitForVerifier"
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
-	rlRun -s "echo 'show databases;' | mysql -u root"
-	rlAssertGrep "verifierdb" $rlRun_LOG
-	rlAssertGrep "registrardb" $rlRun_LOG
+        rlRun -s "echo 'show databases;' | mysql -u root"
+        rlAssertGrep "verifierdb" $rlRun_LOG
+        rlAssertGrep "registrardb" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Test adding keylime tenant"
         rlRun "limeStartAgent"
-        sleep 5
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         # create allowlist and excludelist
         limeCreateTestLists
-        AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
         rlRun "lime_keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f /etc/hostname -c add"
-        rlRun "limeWaitForTenantStatus $AGENT_ID 'Get Quote'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
         rlRun -s "lime_keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
     rlPhaseEnd

--- a/functional/db-postgresql-sanity-on-localhost/test.sh
+++ b/functional/db-postgresql-sanity-on-localhost/test.sh
@@ -59,19 +59,19 @@ rlJournalStart
         rlRun "limeWaitForVerifier"
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
-	rlRun -s "sudo -u postgres psql -c 'SELECT datname FROM pg_database;'"
-	rlAssertGrep "verifierdb" $rlRun_LOG
-	rlAssertGrep "registrardb" $rlRun_LOG
+        rlRun -s "sudo -u postgres psql -c 'SELECT datname FROM pg_database;'"
+        rlAssertGrep "verifierdb" $rlRun_LOG
+        rlAssertGrep "registrardb" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Test adding keylime tenant"
+        AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
         rlRun "limeStartAgent"
-        sleep 5
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         # create allowlist and excludelist
         limeCreateTestLists
-        AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
         rlRun "lime_keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f /etc/hostname -c add"
-        rlRun "limeWaitForTenantStatus $AGENT_ID 'Get Quote'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
         rlRun -s "lime_keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
     rlPhaseEnd

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -2,6 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
 rlJournalStart
 
@@ -33,16 +34,14 @@ rlJournalStart
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
         rlRun "limeStartAgent"
-        sleep 5
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         # create allowlist and excludelist
         limeCreateTestLists
     rlPhaseEnd
 
-    AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
-
     rlPhaseStartTest "-c add"
         rlRun "lime_keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c add"
-        rlRun "limeWaitForTenantStatus $AGENT_ID 'Get Quote'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
     rlPhaseEnd
 
     rlPhaseStartTest "-c cvlist"
@@ -81,7 +80,7 @@ rlJournalStart
         TESTDIR=`limeCreateTestDir`
         rlRun "echo -e '#!/bin/bash\necho boom' > $TESTDIR/keylime-bad-script.sh && chmod a+x $TESTDIR/keylime-bad-script.sh"
         rlRun "$TESTDIR/keylime-bad-script.sh"
-        rlRun "limeWaitForTenantStatus $AGENT_ID '(Failed|Invalid Quote)'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
 	limeExtendNextExcludelist $TESTDIR
@@ -91,7 +90,7 @@ rlJournalStart
         # create new allowlist and excludelist
         limeCreateTestLists
         rlRun "lime_keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c update"
-        rlRun "limeWaitForTenantStatus $AGENT_ID 'Get Quote'"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
     rlPhaseEnd
 
     rlPhaseStartTest "-c reactivate"


### PR DESCRIPTION
Rename limeWaitForTenantStatus to limeWaitForAgentStatus
Add limeWaitForAgent
Add limeWaitForAgentRegistration
Update existing tests to utilize these functions

These changes are necessary especially for CentOS Stream 8 since some operations seem to be slower there.