### PR TITLE
Add conf_option_usage.sh script

### DIFF
--- a/tools/conf_option_usage.sh
+++ b/tools/conf_option_usage.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This is a simple script that presents the usage of individual keylime.conf
+# options in keylime-tests
+#
+# Usage: cd keylime-tests
+#        tools/conf_option_usage.sh
+
+TESTDIR=$1
+[ -z "$TESTDIR" ] && TESTDIR=$( pwd | sed 's/keylime-tests.*/keylime-tests/' )
+
+pushd $TESTDIR
+
+CONF=$( mktemp )
+SECTION="empty"
+OPTION=""
+DEFAULT=""
+
+curl -sk 'https://raw.githubusercontent.com/keylime/keylime/master/keylime.conf' > $CONF
+
+function used_option_values() {
+  local SECTION=$1
+  local OPTION=$2
+  local VALUE
+  local VALUES
+
+  grep -R "limeUpdateConf $SECTION $OPTION " . | while read LINE; do
+      FILE=$( echo "$LINE" | cut -d ':' -f 1 )
+      VALUE=$( echo "$LINE" | sed "s/.*limeUpdateConf $SECTION $OPTION[ ]*\(.*\)\".*/\1/" )
+      echo "  $VALUE  $FILE"
+  done
+
+}
+
+cat $CONF | while read LINE; do
+
+  # get the first character
+  CHAR=${LINE::1}
+
+  case $CHAR in
+
+    "#"|"")  # comment
+    ;;
+
+    "[")  # section
+      SECTION=$( echo "$LINE" | tr -d '\[\]' )
+      echo -e "\n$LINE"
+    ;;
+
+    *) # anything else
+      OPTION=$( echo "$LINE" | sed 's/[ ]*=.*//')
+      DEFAULT=$( echo "$LINE" | sed 's/.*=[ ]*//')
+      echo -e "\n$OPTION"
+      echo "  $DEFAULT (default)"
+      used_option_values $SECTION $OPTION
+    ;;
+
+  esac
+
+done
+
+rm $CONF


### PR DESCRIPTION
Simple test parser that prints out values used by tests for each keylime.conf option.
It relies on `limeUpdateConf` being used by a test.

E.g.
```
$ tools/conf_option_usage.sh 
~/devel/github/keylime-tests ~/devel/github/keylime-tests

[general]

enable_tls
  True (default)

tls_check_hostnames
  False (default)
  True  ./Multihost/basic-attestation/test.sh
  True  ./Multihost/basic-attestation/test.sh
  True  ./Multihost/basic-attestation/test.sh
  True  ./Multihost/basic-attestation/test.sh

ca_implementation
  openssl (default)

receive_revocation_ip
  127.0.0.1 (default)
  ${REGISTRAR_IP}  ./Multihost/basic-attestation/test.sh
  ${VERIFIER_IP}  ./Multihost/basic-attestation/test.sh
  ${VERIFIER_IP}  ./Multihost/basic-attestation/test.sh

receive_revocation_port
  8992 (default)
...
```