### PR TITLE
Run upstream bits as keylime user

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1294,6 +1294,8 @@ fi
 # create context depending on the test directory by
 # cuting-off the *keylime-tests* (git repo dir) part
 __INTERNAL_limeCoverageContext=$( cat $__INTERNAL_limeLogCurrentTest | sed -e 's#.*keylime-tests[^/]*\(/.*\)#\1#' )
+# we need to save context to a place where systemd can access it without SELinux complaining
+echo "limeCoverageContext=$__INTERNAL_limeCoverageContext" > /etc/systemd/limeLib.context
 
 true <<'=cut'
 =pod

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -79,8 +79,11 @@ User=tss
 WantedBy=multi-user.target
 _EOF"
         # also add drop-in update for eventual keylime_agent unit file
-        rlRun "mkdir /etc/systemd/system/keylime_agent.service.d"
+        rlRun "mkdir -p /etc/systemd/system/keylime_agent.service.d"
         rlRun 'cat > /etc/systemd/system/keylime_agent.service.d/10-tcti.conf <<_EOF
+[Unit]
+# we want to unset this since there is no /dev/tmp0
+ConditionPathExistsGlob=
 [Service]
 Environment="TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd"
 _EOF'

--- a/setup/enable_keylime_coverage/test.sh
+++ b/setup/enable_keylime_coverage/test.sh
@@ -14,4 +14,21 @@ rlJournalStart
         rlRun "coverage --help"
     rlPhaseEnd
 
+    rlPhaseStartSetup "Modify keylime systemd unit files"
+        id keylime && rlRun "chown -R keylime /var/tmp/limeLib && chmod -R g+w /var/tmp/limeLib"
+        for F in agent verifier registrar; do
+            rlRun "mkdir -p /etc/systemd/system/keylime_${F}.service.d"
+            rlRun "cat > /etc/systemd/system/keylime_${F}.service.d/10-coverage.conf <<_EOF
+[Service]
+# set variable containing name of the currently running test
+EnvironmentFile=/etc/systemd/limeLib.context
+# we need to change WorkingDirectory since .coverage* files will be stored there
+WorkingDirectory=/var/tmp/limeLib/coverage
+ExecStart=
+ExecStart=/usr/local/bin/coverage run -p --context \\\${limeCoverageContext} /usr/local/bin/keylime_${F}
+_EOF"
+        done
+	rlRun "systemctl daemon-reload"
+    rlPhaseEnd
+
 rlJournalEnd

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -2,6 +2,8 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+[ "$INSTALL_SERVICE_FILES" == "0" -o "$INSTALL_SERVICE_FILES" == "false" ] && INSTALL_SERVICE_FILES=false || INSTALL_SERVICE_FILES=true
+
 rlJournalStart
 
     rlPhaseStartSetup "Install keylime and its dependencies"
@@ -54,6 +56,10 @@ _EOF'
         rlRun "python3 setup.py install"
         # copy keylime.conf to /etc
         rlRun "cp keylime.conf /etc"
+        if $INSTALL_SERVICE_FILES; then
+            rlRun "cd services; bash installer.sh"
+            rlRun "systemctl daemon-reload"
+        fi
         rlRun "popd"
     rlPhaseEnd
 


### PR DESCRIPTION
Enables service file installation in the /setup/install-upstream-keylime task.
Also, since current service files start all services under `keylime` user we need to do some adjustments
in services files and `lib.sh` so that coverage measurements remain functional.