### PR TITLE
Update basic-attestation-on-localhost to use custom certificates

### DIFF
--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -5,6 +5,7 @@ component:
 test: ./test.sh
 framework: beakerlib
 require:
+- library(openssl/certgen)
 - yum
 - expect
 - tpm2-abrmd


### PR DESCRIPTION
There are already several tests that are using certificates generated by verifier but there is no test using custom certificate except the Multihost one. As a result scenario with custom certificates is not tested in CI.
This change is updating /functional/basic-attestation-on-localhost to generate and use custom certificates.