### PR TITLE
Add and use limeLogfileSubmit instead of rlFileSubmit

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1265,6 +1265,36 @@ limeIMAEmulatorLogfile() {
 
 }
 
+true <<'=cut'
+=pod
+
+=head2 limeLogfileSubmit
+
+Wrapper around Beakerlib function rlFileSubmit that prints the provided file
+to STDOUT if the test failed, i.e. $__INTERNAL_TEST_STATE > 0.
+
+    limeLogfileSubmit FILE
+
+=over
+
+=back
+
+Returns 0.
+
+=cut
+
+
+limeLogfileSubmit() {
+
+    local STATE=${__INTERNAL_TEST_STATE:-0}
+
+    if [ ${STATE} -gt 0 -a -n "$1" ]; then
+        cat $1
+    fi
+    rlFileSubmit $1
+
+}
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Initialization
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -132,7 +132,7 @@ Verifier() {
     rlPhaseStartCleanup "Verifier cleanup"
         rlRun "kill $HTTP_PID"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
     rlPhaseEnd
 }
 
@@ -181,7 +181,7 @@ Registrar() {
 
     rlPhaseStartCleanup "Registrar cleanup"
         rlRun "limeStopRegistrar"
-        rlFileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
     rlPhaseEnd
 }
 
@@ -322,10 +322,10 @@ _EOF"
     rlPhaseStartCleanup "Agent cleanup"
         rlRun "sync-set AGENT_ALL_TESTS_DONE"
         rlRun "limeStopAgent"
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         rlServiceRestore tpm2-abrmd
@@ -420,10 +420,10 @@ Agent2() {
         rlRun "kill $HTTP_PID"
         rlRun "rm -f /var/tmp/test_payload_file"
         limeStopAgent
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             limeStopIMAEmulator
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             limeStopTPMEmulator
         fi
         rlServiceRestore tpm2-abrmd

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -196,12 +196,12 @@ _EOF"
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         rlRun "rm /etc/pki/ca-trust/source/anchors/keylime-ca.crt"

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -100,12 +100,12 @@ _EOF"
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         if [ -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf ]; then

--- a/functional/db-mariadb-sanity-on-localhost/test.sh
+++ b/functional/db-mariadb-sanity-on-localhost/test.sh
@@ -80,12 +80,12 @@ rlJournalStart
         rlRun "limeStopVerifier"
         rlServiceStop mariadb
         # submit log files
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         # restore files and services

--- a/functional/db-mysql-sanity-on-localhost/test.sh
+++ b/functional/db-mysql-sanity-on-localhost/test.sh
@@ -91,12 +91,12 @@ rlJournalStart
         rlRun "limeStopVerifier"
         rlServiceStop mysqld
         # submit log files
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
 

--- a/functional/db-postgresql-sanity-on-localhost/test.sh
+++ b/functional/db-postgresql-sanity-on-localhost/test.sh
@@ -83,12 +83,12 @@ rlJournalStart
         rlRun "limeStopVerifier"
         rlServiceStop postgresql
         # submit log files
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         # restore files and services

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -121,12 +121,12 @@ rlJournalStart
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         rlServiceRestore tpm2-abrmd

--- a/functional/tenant-allowlist-sanity/test.sh
+++ b/functional/tenant-allowlist-sanity/test.sh
@@ -183,12 +183,12 @@ EOF"
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         limeClearData

--- a/functional/tpm_policy-sanity-on-localhost/test.sh
+++ b/functional/tpm_policy-sanity-on-localhost/test.sh
@@ -80,12 +80,12 @@ rlJournalStart
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
-        rlFileSubmit $(limeVerifierLogfile)
-        rlFileSubmit $(limeRegistrarLogfile)
-        rlFileSubmit $(limeAgentLogfile)
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
-            rlFileSubmit $(limeIMAEmulatorLogfile)
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
         fi
         rlServiceRestore tpm2-abrmd


### PR DESCRIPTION
In CI we cannot attach logfiles and therefore cannot troubleshoot occasional failures.
This changes adds function `limeLogfileSubmit` as an alternative to `rlFileSubmit` that
prints file content to STDOUT in case the test have failed.