### PR TITLE
Fix code coverage measurement for async code

### DIFF
--- a/setup/enable_keylime_coverage/main.fmf
+++ b/setup/enable_keylime_coverage/main.fmf
@@ -5,8 +5,12 @@ component:
 test: ./test.sh
 framework: beakerlib
 require:
+  - python3
   - python3-pip
+  - python3-devel
   - yum
+  - gcc
+recommend:
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612766

--- a/setup/enable_keylime_coverage/test.sh
+++ b/setup/enable_keylime_coverage/test.sh
@@ -25,7 +25,7 @@ EnvironmentFile=/etc/systemd/limeLib.context
 # we need to change WorkingDirectory since .coverage* files will be stored there
 WorkingDirectory=/var/tmp/limeLib/coverage
 ExecStart=
-ExecStart=/usr/local/bin/coverage run -p --context \\\${limeCoverageContext} /usr/local/bin/keylime_${F}
+ExecStart=/usr/local/bin/coverage run /usr/local/bin/keylime_${F}
 _EOF"
         done
 	rlRun "systemctl daemon-reload"


### PR DESCRIPTION
We need to set --concurrency parameter accordingly and follow
https://coverage.readthedocs.io/en/stable/cmd.html?highlight=concurrency#cmd-run