### PR TITLE
Specify source parameter in coveragerc and create individual summary reports

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1322,11 +1322,10 @@ if ! grep -q "^$PWD\$" $__INTERNAL_limeLogCurrentTest; then
 fi
 
 # prepare coveragerc file
+KEYLIMESRC=$( ls -d /usr/local/lib/python*/site-packages/keylime-*/keylime )
 cat > /var/tmp/limeLib/coverage/coveragerc <<_EOF
 [run]
-source =
-  /usr/local/bin
-  /usr/local/lib/python*/site-packages/keylime-*/
+source = /usr/local/bin,$KEYLIMESRC
 parallel = True
 concurrency = multiprocessing,thread
 context = foo

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1324,6 +1324,9 @@ fi
 # prepare coveragerc file
 cat > /var/tmp/limeLib/coverage/coveragerc <<_EOF
 [run]
+source =
+  /usr/local/bin
+  /usr/local/lib/python*/site-packages/keylime-*/
 parallel = True
 concurrency = multiprocessing,thread
 context = foo

--- a/setup/generate_coverage_report/test.sh
+++ b/setup/generate_coverage_report/test.sh
@@ -31,15 +31,32 @@ rlJournalStart
         rlRun "coverage combine"
         ls -l .coverage*
         rlAssertExists .coverage
+        # packit summary report
+        rlLogInfo "keylime-tests code coverage summary report"
+        rlRun "coverage report --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
         rlRun "coverage xml --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
         rlRun "mv coverage.xml coverage.packit.xml"
-        rlRun "mv .coverage .coverage-packit"
+        rlRun "mv .coverage .coverage.packit"
+        # testsuite summary report
+        if [ -f coverage.testsuite ]; then
+            rlLogInfo "keylime testsuite code coverage summary report"
+            rlRun "cp coverage.testsuite .coverage"
+            rlRun "coverage report --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
+        fi
+        # unittests summary report
+        if [ -f coverage.unittests ]; then
+            rlLogInfo "keylime unittests code coverage summary report"
+            rlRun "cp coverage.unittests .coverage"
+            rlRun "coverage report --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
+        fi
         # now create overall report including upstream tests
         [ -f coverage.testsuite ] && rlRun "cp coverage.testsuite .coverage.testsuite"
         [ -f coverage.unittests ] && rlRun "cp coverage.unittests .coverage.unittests"
+        rm -f .coverage
         ls -l .coverage*
         rlRun "coverage combine"
         ls -l .coverage*
+        rlLogInfo "combined code coverage summary report"
         rlRun "coverage html --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*' --show-contexts"
         rlRun "coverage report --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
         rlRun "cd .."

--- a/setup/generate_coverage_report/test.sh
+++ b/setup/generate_coverage_report/test.sh
@@ -27,14 +27,19 @@ rlJournalStart
     rlPhaseStartTest "Generate overall coverage report"
         rlRun "pushd ${__INTERNAL_limeCoverageDir}"
         # first create combined report for Packit tests
+        ls -l .coverage*
         rlRun "coverage combine"
+        ls -l .coverage*
         rlAssertExists .coverage
         rlRun "coverage xml --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
         rlRun "mv coverage.xml coverage.packit.xml"
+        rlRun "mv .coverage .coverage-packit"
         # now create overall report including upstream tests
-        [ -f coverage.testsuite ] && cp coverage.testsuite .coverage.testsuite
-        [ -f coverage.unittests ] && cp coverage.unittests .coverage.unittests
+        [ -f coverage.testsuite ] && rlRun "cp coverage.testsuite .coverage.testsuite"
+        [ -f coverage.unittests ] && rlRun "cp coverage.unittests .coverage.unittests"
+        ls -l .coverage*
         rlRun "coverage combine"
+        ls -l .coverage*
         rlRun "coverage html --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*' --show-contexts"
         rlRun "coverage report --include '*keylime*' --omit '/var/lib/keylime/secure/unzipped/*'"
         rlRun "cd .."


### PR DESCRIPTION
We were not specifying --source for the coverage script and therefore we were measuring only files that were executed. By specifying --source we should get more precise measurements (and lower numbers too).