### PR TITLE
[WIP] Define TPM2TOOLS_TCTI and TCTI globally in /etc/profile.d

### DIFF
--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -246,7 +246,6 @@ Agent() {
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
             limeInstallIMAConfig
             rlRun "limeStartIMAEmulator"
         else
@@ -378,7 +377,6 @@ Agent2() {
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
             limeInstallIMAConfig
             limeStartIMAEmulator
         else

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -105,8 +105,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -24,8 +24,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -24,7 +24,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else
@@ -39,9 +38,8 @@ rlJournalStart
         # when using unit files we need to adjust them
         if [ -f /usr/lib/systemd/system/keylime_agent.service -o -f /etc/systemd/system/keylime_agent.service ]; then
             rlRun "mkdir -p /etc/systemd/system/keylime_agent.service.d/"
-            rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf <<_EOF
+            rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
 [Service]
-Environment=\"TCTI=${TPM2TOOLS_TCTI}\"
 Environment=\"RUST_LOG=keylime_agent=trace\"
 _EOF"
             rlRun "systemctl daemon-reload"
@@ -62,7 +60,7 @@ _EOF"
         if [ -f /usr/lib/systemd/system/keylime_agent.service -o -f /etc/systemd/system/keylime_agent.service ]; then
             rlRun "limeStartAgent"
         else
-            rlRun "TCTI=${TPM2TOOLS_TCTI} RUST_LOG=keylime_agent=trace limeStartAgent"
+            rlRun "RUST_LOG=keylime_agent=trace limeStartAgent"
         fi
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}" 1
         rlAssertGrep "enable_insecure_payload. has to be set to .True." $(limeAgentLogfile) -E
@@ -74,7 +72,7 @@ _EOF"
             rlRun "systemctl daemon-reload"
             rlRun "limeStartAgent"
         else
-            rlRun "TCTI=${TPM2TOOLS_TCTI} RUST_LOG=keylime_agent=trace limeStartAgent"
+            rlRun "RUST_LOG=keylime_agent=trace limeStartAgent"
         fi
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         rlRun "expect add.expect"
@@ -95,7 +93,7 @@ _EOF"
             rlRun "systemctl daemon-reload"
             rlRun "limeStartAgent"
         else
-            rlRun "TCTI=${TPM2TOOLS_TCTI} RUST_LOG=keylime_agent=trace limeStartAgent"
+            rlRun "RUST_LOG=keylime_agent=trace limeStartAgent"
         fi
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
     rlPhaseEnd

--- a/functional/db-mariadb-sanity-on-localhost/test.sh
+++ b/functional/db-mariadb-sanity-on-localhost/test.sh
@@ -19,8 +19,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/db-mysql-sanity-on-localhost/test.sh
+++ b/functional/db-mysql-sanity-on-localhost/test.sh
@@ -37,8 +37,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/db-postgresql-sanity-on-localhost/test.sh
+++ b/functional/db-postgresql-sanity-on-localhost/test.sh
@@ -18,8 +18,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -21,7 +21,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/tenant-allowlist-sanity/test.sh
+++ b/functional/tenant-allowlist-sanity/test.sh
@@ -24,8 +24,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/functional/tpm_policy-sanity-on-localhost/test.sh
+++ b/functional/tpm_policy-sanity-on-localhost/test.sh
@@ -19,8 +19,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -21,7 +21,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Test installed binaries"
-        rlRun "TCTI=tabrmd keylime_agent --help" 0,1
+        rlRun "keylime_agent --help" 0,1
     rlPhaseEnd
 
 rlJournalEnd

--- a/upstream/run_keylime_tests/test.sh
+++ b/upstream/run_keylime_tests/test.sh
@@ -37,8 +37,6 @@ rlJournalStart
             rlServiceStart tpm2-abrmd
             sleep 5
             # start ima emulator
-            export TPM2TOOLS_TCTI=tabrmd:bus_name=com.intel.tss2.Tabrmd
-            export TCTI=tabrmd:
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         else


### PR DESCRIPTION
Instead of defining these variable in each test /setup/configure_tpm_emulator defines them globally in /etc/profile.d/ and extends agent unit file.