### PR TITLE
Remove tpm2-abrmd usage on systems with read TPM device

### DIFF
--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -19,7 +19,6 @@ require:
   - yum
   - bind-utils
   - expect
-  - tpm2-abrmd
 recommend:
   - keylime
   - keylime-verifier

--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -248,8 +248,6 @@ Agent() {
             # start ima emulator
             limeInstallIMAConfig
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
 
@@ -326,8 +324,8 @@ _EOF"
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
-        rlServiceRestore tpm2-abrmd
         rlRun "rm -f /var/tmp/test_payload_file"
     rlPhaseEnd
 }
@@ -379,8 +377,6 @@ Agent2() {
             # start ima emulator
             limeInstallIMAConfig
             limeStartIMAEmulator
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
 
@@ -423,8 +419,8 @@ Agent2() {
             limeStopIMAEmulator
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             limeStopTPMEmulator
+            rlServiceRestore tpm2-abrmd
         fi
-        rlServiceRestore tpm2-abrmd
     rlPhaseEnd
 }
 

--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -17,7 +17,6 @@ require:
 - library(openssl/certgen)
 - yum
 - expect
-- tpm2-abrmd
 - openssl
 - nmap-ncat
 recommend:

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -107,8 +107,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # start keylime_verifier
@@ -197,13 +195,13 @@ _EOF"
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         rlRun "rm /etc/pki/ca-trust/source/anchors/keylime-ca.crt"
         rlRun "update-ca-trust"
         limeClearData
         limeRestoreConfig
         limeExtendNextExcludelist $TESTDIR
-        rlServiceRestore tpm2-abrmd
         #rlRun "rm -f $TESTDIR/keylime-bad-script.sh"  # possible but not really necessary
     rlPhaseEnd
 

--- a/functional/basic-attestation-with-unpriviledged-agent/main.fmf
+++ b/functional/basic-attestation-with-unpriviledged-agent/main.fmf
@@ -11,7 +11,6 @@ framework: beakerlib
 require:
   - yum
   - expect
-  - tpm2-abrmd
   - openssl
   - nmap-ncat
 recommend:

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -26,8 +26,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # start keylime_verifier
@@ -103,12 +101,12 @@ _EOF"
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         if [ -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf ]; then
             rlRun "rm -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf"
             rlRun "systemctl daemon-reload"
         fi
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         limeExtendNextExcludelist $TESTDIR

--- a/functional/basic-attestation-without-mtls/main.fmf
+++ b/functional/basic-attestation-without-mtls/main.fmf
@@ -20,7 +20,6 @@ framework: beakerlib
 require:
   - yum
   - expect
-  - tpm2-abrmd
   - openssl
   - nmap-ncat
 recommend:

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -26,8 +26,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # start keylime_verifier
@@ -131,12 +129,12 @@ _EOF"
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         if [ -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf ]; then
             rlRun "rm -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf"
             rlRun "systemctl daemon-reload"
         fi
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         limeExtendNextExcludelist $TESTDIR

--- a/functional/db-mariadb-sanity-on-localhost/main.fmf
+++ b/functional/db-mariadb-sanity-on-localhost/main.fmf
@@ -13,7 +13,6 @@ require:
   - yum
   - mariadb-server
   - python3-PyMySQL
-  - tpm2-abrmd
   - tpm2-tools
 recommend:
   - keylime

--- a/functional/db-mariadb-sanity-on-localhost/test.sh
+++ b/functional/db-mariadb-sanity-on-localhost/test.sh
@@ -21,8 +21,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
 
         # backup and configure mariadb
@@ -83,9 +81,9 @@ rlJournalStart
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         # restore files and services
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         rlFileRestore

--- a/functional/db-mysql-sanity-on-localhost/main.fmf
+++ b/functional/db-mysql-sanity-on-localhost/main.fmf
@@ -15,7 +15,6 @@ adjust:
 require:
   - yum
   - python3-PyMySQL
-  - tpm2-abrmd
   - tpm2-tools
 recommend:
   - keylime

--- a/functional/db-mysql-sanity-on-localhost/test.sh
+++ b/functional/db-mysql-sanity-on-localhost/test.sh
@@ -39,8 +39,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
 
         # configure keylime
@@ -94,17 +92,17 @@ rlJournalStart
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
 
         # check if mariadb was installed and reinstall it
-	if [ -n "$PKGS" ]; then
+        if [ -n "$PKGS" ]; then
             rlRun "yum -y remove mysql-server"
             rlRun "yum -y install $PKGS"
             rlRun "rpm -q $PKGS"
         fi
 
         # restore files and services
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         rlFileRestore

--- a/functional/db-postgresql-sanity-on-localhost/main.fmf
+++ b/functional/db-postgresql-sanity-on-localhost/main.fmf
@@ -14,7 +14,6 @@ require:
   - postgresql-server
   - postgresql-contrib
   - python3-psycopg2
-  - tpm2-abrmd
   - tpm2-tools
 recommend:
   - keylime

--- a/functional/db-postgresql-sanity-on-localhost/test.sh
+++ b/functional/db-postgresql-sanity-on-localhost/test.sh
@@ -20,8 +20,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
 
         # backup and configure postgresql db
@@ -86,9 +84,9 @@ rlJournalStart
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         # restore files and services
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         rlFileRestore

--- a/functional/keylime_tenant-commands-on-localhost/main.fmf
+++ b/functional/keylime_tenant-commands-on-localhost/main.fmf
@@ -10,7 +10,6 @@ test: ./test.sh
 framework: beakerlib
 require:
   - yum
-  - tpm2-abrmd
 recommend:
   - keylime
   - keylime-verifier

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -23,8 +23,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # start keylime_verifier
@@ -127,8 +125,8 @@ rlJournalStart
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
         limeExtendNextExcludelist $TESTDIR

--- a/functional/tenant-allowlist-sanity/main.fmf
+++ b/functional/tenant-allowlist-sanity/main.fmf
@@ -7,7 +7,6 @@ test: ./test.sh
 framework: beakerlib
 require:
   - yum
-  - tpm2-abrmd
   - openssl
   - gnupg2
 recommend:

--- a/functional/tenant-allowlist-sanity/test.sh
+++ b/functional/tenant-allowlist-sanity/test.sh
@@ -26,8 +26,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # start keylime_verifier
@@ -204,10 +202,10 @@ EOF"
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
         limeClearData
         limeRestoreConfig
-        rlServiceRestore tpm2-abrmd
         rlRun "popd"
         rlRun "rm -rf ${TmpDir}"
         rlRun "gpgconf --kill gpg-agent"

--- a/functional/tpm_policy-sanity-on-localhost/main.fmf
+++ b/functional/tpm_policy-sanity-on-localhost/main.fmf
@@ -12,7 +12,6 @@ test: ./test.sh
 framework: beakerlib
 require:
   - yum
-  - tpm2-abrmd
   - tpm2-tools
 recommend:
   - keylime

--- a/functional/tpm_policy-sanity-on-localhost/test.sh
+++ b/functional/tpm_policy-sanity-on-localhost/test.sh
@@ -21,8 +21,6 @@ rlJournalStart
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         sleep 5
         # update /etc/keylime.conf
@@ -82,8 +80,8 @@ rlJournalStart
             rlRun "limeStopIMAEmulator"
             limeLogfileSubmit $(limeIMAEmulatorLogfile)
             rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
         fi
-        rlServiceRestore tpm2-abrmd
         limeClearData
         limeRestoreConfig
     rlPhaseEnd

--- a/upstream/run_keylime_tests/main.fmf
+++ b/upstream/run_keylime_tests/main.fmf
@@ -6,7 +6,6 @@ test: ./test.sh
 framework: beakerlib
 require:
 - yum
-- tpm2-abrmd
 - openssl
 - python3-cryptography
 - python3-pyyaml


### PR DESCRIPTION
When we do not start TPM emulator in a test we do not need
tpm2-abrmd since the support for real TPM device is provided
by kernel.