### PR TITLE
Do not use LEGACY crypto policy

### DIFF
--- a/Library/test-helpers/create_allowlist.sh
+++ b/Library/test-helpers/create_allowlist.sh
@@ -17,7 +17,7 @@ fi
 if [ "$2" != "--" ]; then
     ALGO=$2
 else
-    ALGO=sha1sum
+    ALGO=sha256sum
 fi
 
 OUTPUT=$(readlink -f $1)
@@ -47,5 +47,5 @@ done
 # The boot_aggregate measurement is always the first line in the IMA Log file.
 # The format of the log lines is the following:
 #     <PCR_ID> <PCR_Value> <IMA_Template> <File_Digest> <File_Name> <File_Signature>
-# File_Digest may start with the digest algorithm specified (e.g "sha1:", "sha256:") depending on the template used.
+# File_Digest may start with the digest algorithm specified (e.g "sha256:") depending on the template used.
 head -n 1 /sys/kernel/security/ima/ascii_runtime_measurements | awk '{ print $4 "  boot_aggregate" }' | sed 's/.*://' >> $OUTPUT

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -285,6 +285,12 @@ __limeStartKeylimeService() {
 
     local NAME=$1
     local LOGFILE=$( __limeGetLogName $1 $2 )
+    local ARGS
+
+    # set sha256 as default hash for ima emulator
+    if [ "$1" == "ima_emulator" ]; then
+        ARGS="--hash_algs sha256 --ima-hash-alg sha256"
+    fi
 
     # execute service using sytemd unit file
     if limeServiceUnitFileExists keylime_${NAME}; then
@@ -293,10 +299,10 @@ __limeStartKeylimeService() {
     # if there is no unit file, execute the process directly
     else
         if $__INTERNAL_limeCoverageEnabled && file $(which keylime_${NAME}) | grep -qi python; then
-            coverage run $(which keylime_${NAME}) >> ${LOGFILE} 2>&1 &
+            coverage run $(which keylime_${NAME}) ${ARGS} >> ${LOGFILE} 2>&1 &
         else
             # export RUST_LOG=keylime_agent=trace just in case we are using rust-keylime
-            RUST_LOG=keylime_agent=trace keylime_${NAME} >> ${LOGFILE} 2>&1 &
+            RUST_LOG=keylime_agent=trace keylime_${NAME} ${ARGS} >> ${LOGFILE} 2>&1 &
         fi
     fi
 

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -4,10 +4,14 @@ adjust:
     enabled: false
     when: distro = centos-stream
 prepare:
-  how: shell
-  script:
-   - rm -f /etc/yum.repos.d/tag-repository.repo
-   - dnf config-manager --set-enabled updates-testing updates-testing-modular
+  - how: shell
+    script:
+     - rm -f /etc/yum.repos.d/tag-repository.repo
+     - dnf config-manager --set-enabled updates-testing updates-testing-modular
+  - how: shell
+    order: 90
+    script:
+     - sed -i "s/tpm_hash_alg =.*/tpm_hash_alg = sha256/" /etc/keylime.conf
 discover:
   how: fmf
   test: 

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -59,7 +59,7 @@ Description=swtpm TPM Software emulator
 [Service]
 Type=fork
 ExecStartPre=/usr/bin/mkdir -p /var/lib/tpm/swtpm
-ExecStartPre=/usr/bin/swtpm_setup --tpm-state /var/lib/tpm/swtpm --createek --decryption --create-ek-cert --create-platform-cert --lock-nvram --overwrite --display --tpm2 --pcr-banks sha1,sha256
+ExecStartPre=/usr/bin/swtpm_setup --tpm-state /var/lib/tpm/swtpm --createek --decryption --create-ek-cert --create-platform-cert --lock-nvram --overwrite --display --tpm2 --pcr-banks sha256
 ExecStart=/usr/bin/swtpm socket --tpmstate dir=/var/lib/tpm/swtpm --log level=4 --ctrl type=tcp,port=2322 --server type=tcp,port=2321 --flags startup-clear --tpm2
 
 [Install]

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -18,12 +18,6 @@ rlJournalStart
         if rlIsFedora; then
             FEDORA_EXTRA_PKGS="python3-lark-parser python3-packaging"
         else
-            # on C9S we need to enable LEGACY crypto policy to enable SHA1 RPM signatures
-            if rlIsRHEL 9 || rlIsCentOS 9; then
-                rlRun "dnf upgrade -y https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-20220223-1.git5203b41.el9.noarch.rpm https://kojihub.stream.centos.org/kojifiles/packages/crypto-policies/20220223/1.git5203b41.el9/noarch/crypto-policies-scripts-20220223-1.git5203b41.el9.noarch.rpm"
-                rlRun "update-crypto-policies --set LEGACY"
-            fi
-
             rlRun 'cat > /etc/yum.repos.d/keylime.repo <<_EOF
 [copr:copr.fedorainfracloud.org:scorreia:keylime]
 name=Copr repo for keylime owned by scorreia
@@ -71,6 +65,8 @@ _EOF'
         rlRun "python3 setup.py install"
         # copy keylime.conf to /etc
         rlRun "cp keylime.conf /etc"
+        # need to update default hash algorithm to sha256, sha1 is obsolete
+        rlRun "sed -i 's/tpm_hash_alg =.*/tpm_hash_alg = sha256/' /etc/keylime.conf"
         if $INSTALL_SERVICE_FILES; then
             rlRun "cd services; bash installer.sh"
             rlRun "systemctl daemon-reload"


### PR DESCRIPTION
The official distributed crypto-policies should now work without the need to set the policy to the LEGACY state. It will be see in CI here.