### PR TITLE
Add KEYLIME_TEST_DISABLE_REVOCATION envvar

### DIFF
--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -6,7 +6,7 @@ description: |
  Registers both agent2 providing a payload with autorun.sh and python revocation script.
  Verifiers that systems passed attestation and autorun.sh has been executed.
  Does changes on a system with agent1 and verifies that system has failed attestation.
- Confirms that the revocation script has been executed only on both agents.
+ Confirms that the revocation script has been executed only on both agents unless revocation is disabled through the KEYLIME_TEST_DISABLE_REVOCATION environment variable.
 contact: Karel Srot <ksrot@redhat.com>
 component:
   - keylime

--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -6,7 +6,7 @@ description: |
  Registers agent providing a payload with autorun.sh and python revocation script.
  Verifiers that system passed attestation and autorun.sh has been executed.
  Does changes on a system and verifies that system has failed attestation.
- Confirms that the revocation script has been executed.
+ Confirms that the revocation script has been executed unless revocation is disabled through the KEYLIME_TEST_DISABLE_REVOCATION environment variable.
  Confirms that webhook_notifier connected to the configured URL over HTTPS.
 contact: Karel Srot <ksrot@redhat.com>
 component:

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -15,6 +15,10 @@ rlJournalStart
         limeBackupConfig
         # update /etc/keylime.conf
         rlRun "limeUpdateConf tenant require_ek_cert False"
+        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
+            rlRun "limeUpdateConf cloud_agent listen_notifications False"
+        fi
         # if TPM emulator is present
         if limeTPMEmulated; then
             # start tpm emulator
@@ -84,10 +88,12 @@ _EOF"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
-        rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
-        rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
-        rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"
-        rlAssertNotExists /var/tmp/test_payload_file
+        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+            rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
+            rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
+            rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"
+            rlAssertNotExists /var/tmp/test_payload_file
+        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup "Do the keylime cleanup"

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -15,6 +15,10 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_agent mtls_cert_enabled False"
         rlRun "limeUpdateConf cloud_agent enable_insecure_payload False"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_cert_enabled False"
+        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
+            rlRun "limeUpdateConf cloud_agent listen_notifications False"
+        fi
         # if TPM emulator is present
         if limeTPMEmulated; then
             # start tpm emulator
@@ -89,10 +93,12 @@ _EOF"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
-        rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
-        rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
-        rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"
-        rlAssertNotExists /var/tmp/test_payload_file
+        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+            rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
+            rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
+            rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"
+            rlAssertNotExists /var/tmp/test_payload_file
+        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup "Do the keylime cleanup"

--- a/plans/basic-attestation-without-revocation.fmf
+++ b/plans/basic-attestation-without-revocation.fmf
@@ -1,0 +1,42 @@
+summary:
+  Tests upstream keylime without revocation actions
+
+environment:
+  KEYLIME_TEST_DISABLE_REVOCATION: 1
+
+prepare:
+  how: shell
+  script:
+   - rm -f /etc/yum.repos.d/tag-repository.repo
+
+discover:
+  how: fmf
+  test: 
+   - /setup/configure_tpm_emulator
+   - /setup/install_upstream_keylime
+   - /setup/enable_keylime_coverage
+   - "/functional/basic-attestation-.*"
+   - /setup/generate_coverage_report
+
+execute:
+    how: tmt
+
+adjust:
+  - when: distro == centos-stream-9
+    prepare+:
+       script+:
+        - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+  - when: distro == centos-stream-8
+    prepare+:
+       script+:
+         - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+#         - yum config-manager --set-enabled powertools
+
+  # discover step adjustments
+  # disable code coverage measurement everywhere except F35 and CS9
+  - when: distro != centos-stream-9 and distro != fedora-35
+    discover+:
+       test-:
+         - /setup/enable_keylime_coverage
+         - /setup/generate_coverage_report

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -43,7 +43,11 @@ _EOF'
                 RHEL_EXTRA_PKGS="$RHEL_EXTRA_PKGS python3-packaging"
             fi
         fi
-        rlRun "yum -y install $FEDORA_EXTRA_PKGS $RHEL_EXTRA_PKGS git-core python3-pip python3-pyyaml python3-tornado python3-requests python3-sqlalchemy python3-alembic python3-psutil python3-gnupg python3-cryptography libselinux-python3 procps-ng tpm2-abrmd tpm2-tss tpm2-tools python3-zmq patch"
+        rlRun "yum -y install $FEDORA_EXTRA_PKGS $RHEL_EXTRA_PKGS git-core python3-pip python3-pyyaml python3-tornado python3-requests python3-sqlalchemy python3-alembic python3-psutil python3-gnupg python3-cryptography libselinux-python3 procps-ng tpm2-abrmd tpm2-tss tpm2-tools patch"
+	# enable the following condition once https://github.com/keylime/keylime/pull/987 is merged
+	# if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+            rlRun "yum -y install python3-zmq"
+	# fi
         # need to install few more pgs from pip on RHEL
         if ! rlIsFedora; then
             rlRun "pip3 install lark-parser $RHEL_EXTRA_PIP_PKGS"


### PR DESCRIPTION
This changes the basic attestation tests to take into account of the
KEYLIME_TEST_DISABLE_REVOCATION environment variable, which disables
ZeroMQ based revocation notification.

Signed-off-by: Daiki Ueno <dueno@redhat.com>