### PR TITLE
Use simpler conditional to check KEYLIME_TEST_DISABLE_REVOCATION

### DIFF
--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -70,7 +70,7 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_verifier agent_mtls_private_key ${CERTDIR}/verifier-client-key.pem"
         rlRun "limeUpdateConf cloud_verifier revocation_notifier_webhook yes"
         rlRun "limeUpdateConf cloud_verifier webhook_url https://localhost:${SSL_SERVER_PORT}"
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
         fi
         # tenant
@@ -99,7 +99,7 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_agent keylime_ca ${CERTDIR}/cacert.pem"
         rlRun "limeUpdateConf cloud_agent rsa_keyname agent-key.pem"
         rlRun "limeUpdateConf cloud_agent mtls_cert agent-cert.pem"
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf cloud_agent listen_notifications False"
         fi
         # if TPM emulator is present
@@ -178,7 +178,7 @@ _EOF"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
             rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
             rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -15,7 +15,7 @@ rlJournalStart
         limeBackupConfig
         # update /etc/keylime.conf
         rlRun "limeUpdateConf tenant require_ek_cert False"
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
             rlRun "limeUpdateConf cloud_agent listen_notifications False"
         fi
@@ -88,7 +88,7 @@ _EOF"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
             rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
             rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -15,7 +15,7 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_agent mtls_cert_enabled False"
         rlRun "limeUpdateConf cloud_agent enable_insecure_payload False"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_cert_enabled False"
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION+set} = set; then
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
             rlRun "limeUpdateConf cloud_agent listen_notifications False"
         fi
@@ -93,7 +93,7 @@ _EOF"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/keylime-bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
             rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
             rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -38,7 +38,7 @@ _EOF'
             fi
         fi
         rlRun "yum -y install $FEDORA_EXTRA_PKGS $RHEL_EXTRA_PKGS git-core python3-pip python3-pyyaml python3-tornado python3-requests python3-sqlalchemy python3-alembic python3-psutil python3-gnupg python3-cryptography libselinux-python3 procps-ng tpm2-abrmd tpm2-tss tpm2-tools patch"
-        if test ${KEYLIME_TEST_DISABLE_REVOCATION-unset} = unset; then
+        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "yum -y install python3-zmq"
         fi
         # need to install few more pgs from pip on RHEL


### PR DESCRIPTION
Also remove the leftover failure test in Multihost/basic-attestation.

Signed-off-by: Daiki Ueno <dueno@redhat.com>