### PR TITLE
plans/rust-keylime-tests: Add basic-attestation-with-unpriviledged-agent

### DIFF
--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -14,6 +14,7 @@ discover:
    - /setup/install_upstream_rust_keylime
    - /functional/basic-attestation-on-localhost
    - /functional/basic-attestation-without-mtls
+   - /functional/basic-attestation-with-unpriviledged-agent
    - /functional/keylime_tenant-commands-on-localhost
 
 execute:


### PR DESCRIPTION
Add the test for unprivileged agent to the rust keylime agent test plan.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>