### PR TITLE
Add /functional/install-rpm-with-ima-signature

### DIFF
--- a/functional/basic-attestation-with-ima-signatures/test.sh
+++ b/functional/basic-attestation-with-ima-signatures/test.sh
@@ -38,7 +38,7 @@ rlJournalStart
         SCRIPT="${TESTDIR}/echo"
         rlRun "echo -e '#!/bin/bash\necho boom' > ${SCRIPT} && chmod a+x ${SCRIPT} && chown ${limeTestUser}.${limeTestUser} ${SCRIPT}"
         ls -l ${SCRIPT}
-        #ALG_ARG="-a sha256"
+        ALG_ARG="-a sha256"
         rlRun "evmctl ima_sign ${ALG_ARG} ${SCRIPT}"
         rlRun -s "getfattr -m ^security.ima --dump ${SCRIPT}"
         rlRun "evmctl ima_verify ${ALG_ARG} ${SCRIPT}"

--- a/functional/install-rpm-with-ima-signature/main.fmf
+++ b/functional/install-rpm-with-ima-signature/main.fmf
@@ -1,0 +1,42 @@
+summary: Installs RPM with a file signed with IMA signature
+description: |
+    Registers an agent on the verifier and confirms is passes attestation.
+    Then install custom built RPM having a file signed with IMA signature
+    and verifies that a system still passes attestation.
+    Scenario is heavily inspired by
+    https://en.opensuse.org/SDB:Ima_evm#IMA_and_EVM_in_practice
+    https://bugzilla.redhat.com/show_bug.cgi?id=1896046#c10
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+require:
+  - yum
+  - attr
+  - ima-evm-utils
+  - rpm-build
+  - rpm-sign
+  - gawk
+  - expect
+  - gnupg2
+  - rng-tools
+  - rpm-plugin-ima
+  - pinentry
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
+duration: 5m
+adjust:
+  - when: swtpm == yes
+    enabled: false
+    because: This tests needs TPM device since kernel boot
+  - when: distro <= fedora-36
+    enabled: false
+    because: rpm issue not fixed in F36 https://github.com/rpm-software-management/rpm/pull/1914
+enabled: true
+extra-nitrate: TC#0613628

--- a/functional/install-rpm-with-ima-signature/rpm-ima-sign-test.spec
+++ b/functional/install-rpm-with-ima-signature/rpm-ima-sign-test.spec
@@ -1,0 +1,25 @@
+# expects limetster user and group to be present on a test sytem
+# build with
+# $ rpmbuild -bb -D 'destdir /some/destination/dir' rpm-ima-sign-test.spec
+
+Summary: This is the rpm-ima-sign-test package
+Name: rpm-ima-sign-test
+Version: 1
+Release: 1
+Group: System Environment/Base
+License: GPL
+BuildArch: noarch
+BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%description
+
+This is a rpm-ima-sign-test test package
+
+%build
+echo -e '#!/bin/bash\necho' > rpm-ima-sign-test-echo
+
+%install
+mkdir -p %{buildroot}/%{destdir}
+mv rpm-ima-sign-test-echo %{buildroot}/%{destdir}
+
+%files
+%attr(755, limetester, limetester) %{destdir}/rpm-ima-sign-test-echo

--- a/functional/install-rpm-with-ima-signature/test.sh
+++ b/functional/install-rpm-with-ima-signature/test.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# This test requires HW TMP
+
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+AGENT_USER=kagent
+AGENT_GROUP=tss
+AGENT_WORKDIR=/var/lib/keylime-agent
+
+TEST_SRC_DIR=$PWD
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        # if TPM emulator is present, stop
+        limeTPMEmulated && rlDie "This test requires TPM device to be present since kernel boot"
+        rlAssertExists ${limeIMAPublicKey} || rlDie "This test requires ${imeIMAPublicKey} to be present on a system"
+        rlAssertRpm keylime
+        limeBackupConfig
+
+	# update /etc/keylime.conf
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
+        rlRun "limeUpdateConf cloud_agent listen_notifications False"
+
+        # start keylime_verifier
+        rlRun "limeStartVerifier"
+        rlRun "limeWaitForVerifier"
+        rlRun "limeStartRegistrar"
+        rlRun "limeWaitForRegistrar"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+
+        # create TMPDIR
+	rlRun "TMPDIR=\$( mktemp -d )"
+        rlRun "pushd ${TMPDIR}"
+
+	# create allowlist and excludelist
+        limeCreateTestLists
+
+	# start rngd to provide more random data
+	pidof rngd && ENTROPY=false || ENTROPY=true
+        $ENTROPY && rlRun "rngd -r /dev/urandom -o /dev/random" 0 "Start rngd to generate random numbers"
+        [ -d /root/.gnupg ] && rlFileBackup --clean /root/.gnupg /etc/hosts
+
+	# create gpg key for rpm signing
+        cat >gpg.conf <<EOF
+%echo Generating a basic OpenPGP key
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: Lime Tester
+Name-Comment: with simple passphrase
+Name-Email: lime@foo.bar
+Expire-Date: 0
+Passphrase: abc
+# Do a commit here, so that we can later print "done" :-)
+%commit
+%echo done
+EOF
+        rlRun "gpg --batch --gen-key gpg.conf" 0 "Create gpg key"
+        rlRun "gpg --export --armor lime@foo.bar > pub.key" 0 "Create gpg public key"
+        rlRun "rpm --import pub.key" 0 "Import the key"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Prepare test RPM file"
+        TESTDIR=`limeCreateTestDir`
+        rlRun "chmod a+rx ${TESTDIR}"
+        # build test rpm
+        rlRun -s "rpmbuild -bb -D 'destdir ${TESTDIR}' ${TEST_SRC_DIR}/rpm-ima-sign-test.spec"
+        RPM_PATH=$( awk '/Wrote:/ { print $2 }' $rlRun_LOG )
+        # generage GPG key for RPM signing
+        # create expect script for signing packages
+        cat > sign.exp <<EOF
+#!/usr/bin/expect -f
+spawn rpmsign --addsign --signfiles --fskpath=${limeIMAPrivateKey} ${RPM_PATH}
+expect {
+    "Enter pass phrase: " {
+        send -- "abc\r"
+    }
+    "Passphrase: " {
+        send -- "abc\r"
+    }
+}
+expect eof
+EOF
+        # add gpg key to rpm macros
+        [ -f ~/.rpmmacros ] && rlFileBackup ~/.rpmmacros
+        echo "%_gpg_name Lime Tester (with simple passphrase) <lime@foo.bar>" > ~/.rpmmacros
+        rlRun "expect sign.exp"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent"
+        rlRun "lime_keylime_tenant -u ${AGENT_ID} --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt --sign_verification_key ${limeIMAPublicKey} -c add"
+        rlRun "limeWaitForAgentStatus ${AGENT_ID} 'Get Quote'"
+        rlRun -s "lime_keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'${AGENT_ID}'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install RPM file"
+        rlRun "rpm -ivh ${RPM_PATH}"
+        SCRIPT=$( rpm -qlp ${RPM_PATH} )
+        ls -l ${SCRIPT}
+        rlRun -s "getfattr -m ^security.ima --dump ${SCRIPT}"
+        rlRun "evmctl ima_verify -a sha256 ${SCRIPT}"
+        rlRun -s "${SCRIPT} boom"
+        rlRun -s "grep '${SCRIPT}' /sys/kernel/security/ima/ascii_runtime_measurements"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Confirm the system is still compliant"
+        rlRun "sleep 30" 0 "Wait 30 seconds to give verifier some time to do new attestation"
+        rlRun "limeWaitForAgentStatus ${AGENT_ID} 'Get Quote'"
+        rlRun -s "lime_keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'${AGENT_ID}'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        rlRun "popd"
+        rlRun "rpm -e rpm-ima-sign-test"
+        rlRun "limeStopAgent"
+        rlRun "limeStopRegistrar"
+        rlRun "limeStopVerifier"
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
+        limeClearData
+        limeRestoreConfig
+        rlFileRestore
+        limeExtendNextExcludelist ${TESTDIR}
+        #rlRun "rm -f $TESTDIR/keylime-bad-script.sh"  # possible but not really necessary
+    rlPhaseEnd
+
+rlJournalEnd


### PR DESCRIPTION
Test requires HW TPM and therefore won't be run in CI.
Also, on F36 and lower there is an rpm issue causing test failure
https://github.com/rpm-software-management/rpm/pull/1914