### PR TITLE
Clear revocation_notifiers when revocation is disabled

### DIFF
--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -111,6 +111,9 @@ Verifier() {
         rlRun "limeUpdateConf cloud_verifier agent_mtls_cert ${CERTDIR}/verifier-client-cert.pem"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_private_key ${CERTDIR}/verifier-client-key.pem"
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifiers ''"
+            # FIXME: this option is deprecated; remove it once
+            # https://github.com/keylime/keylime/pull/795 is merged
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
         fi
 

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -68,9 +68,14 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_verifier registrar_private_key_pw ''"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_cert ${CERTDIR}/verifier-client-cert.pem"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_private_key ${CERTDIR}/verifier-client-key.pem"
+        # FIXME: this option is deprecated; migrate to revocation_notifiers once
+        # https://github.com/keylime/keylime/pull/795 is merged
         rlRun "limeUpdateConf cloud_verifier revocation_notifier_webhook yes"
         rlRun "limeUpdateConf cloud_verifier webhook_url https://localhost:${SSL_SERVER_PORT}"
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifiers ''"
+            # FIXME: this option is deprecated; remove it once
+            # https://github.com/keylime/keylime/pull/795 is merged
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
         fi
         # tenant

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -16,6 +16,9 @@ rlJournalStart
         # update /etc/keylime.conf
         rlRun "limeUpdateConf tenant require_ek_cert False"
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifiers ''"
+            # FIXME: this option is deprecated; remove it once
+            # https://github.com/keylime/keylime/pull/795 is merged
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
             rlRun "limeUpdateConf cloud_agent listen_notifications False"
         fi

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -16,6 +16,9 @@ rlJournalStart
         rlRun "limeUpdateConf cloud_agent enable_insecure_payload False"
         rlRun "limeUpdateConf cloud_verifier agent_mtls_cert_enabled False"
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf cloud_verifier revocation_notifiers ''"
+            # FIXME: this option is deprecated; remove it once
+            # https://github.com/keylime/keylime/pull/795 is merged
             rlRun "limeUpdateConf cloud_verifier revocation_notifier False"
             rlRun "limeUpdateConf cloud_agent listen_notifications False"
         fi


### PR DESCRIPTION
The enhancement#55 introduces a means to control which revocation
mechanisms are enabled, with a single option (revocation_notifiers).
For easier transition, this resets the option as well as the old
revocation_notifier option.

Signed-off-by: Daiki Ueno <dueno@redhat.com>