### PR TITLE
Set revocation_notifiers in keylime.conf

### DIFF
--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -71,6 +71,8 @@ rlJournalStart
         # FIXME: this option is deprecated; migrate to revocation_notifiers once
         # https://github.com/keylime/keylime/pull/795 is merged
         rlRun "limeUpdateConf cloud_verifier revocation_notifier_webhook yes"
+        ###
+        rlRun "limeUpdateConf cloud_verifier revocation_notifiers zeromq,webhook"
         rlRun "limeUpdateConf cloud_verifier webhook_url https://localhost:${SSL_SERVER_PORT}"
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf cloud_verifier revocation_notifiers ''"


### PR DESCRIPTION
We need to set `revocation_notifiers` accordingly so that test scenario remains functional after `revocation_notifier_webhook` gets removed from `keylime.conf` in https://github.com/keylime/keylime/pull/795