### PR TITLE
Enable adding new option to keylime.conf in limeUpdateConf

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -177,7 +177,15 @@ Return success.
 
 
 function limeUpdateConf() {
-  sed -i "/^\[$1\]/,/^\[/ s|^$2 *=.*|$2 = $3|$4" /etc/keylime.conf
+
+  # if the option exists, modify it
+  if sed -n "/^\[$1\]/,/^\[/ p" /etc/keylime.conf | egrep -q "^$2 *="; then
+      sed -i "/^\[$1\]/,/^\[/ s|^$2 *=.*|$2 = $3|$4" /etc/keylime.conf
+  # else we will to add it at the top of the section
+  else
+      sed -i "s|^\[$1\]|\[$1\]\n$2 = $3|$4" /etc/keylime.conf
+  fi
+
 }
 
 


### PR DESCRIPTION
Previously, we were able only to modify an option in keylime.conf if it existed in the respective section.
Now, if the option does not exist it will be added.
This may be useful for testing a backwards compatibility code.