### PR TITLE
Make all .coverage files root readable before processing

### DIFF
--- a/setup/generate_coverage_report/test.sh
+++ b/setup/generate_coverage_report/test.sh
@@ -37,6 +37,7 @@ rlJournalStart
     rlPhaseStartTest "Generate overall coverage report"
         rlRun "pushd ${__INTERNAL_limeCoverageDir}"
         # first create combined report for Packit tests
+        rlRun "chmod a+x *"
         ls -l .coverage*
         rlRun "coverage combine"
         ls -l .coverage*


### PR DESCRIPTION
There is a chance that some .coverage files were not processed due to being readable only by the owner `keylime`.