### PR TITLE
Test scenario checking EK on TPM

### DIFF
--- a/functional/ek-cert-use-ek_check_script/main.fmf
+++ b/functional/ek-cert-use-ek_check_script/main.fmf
@@ -1,0 +1,29 @@
+summary:  Test of keylime checking of endorsment key by script
+description: |
+    Running all services on localhost.
+    Configures agent to validate EK cert through ek_check_script
+    Starts verifier, registrar, agent.
+    Add script for verify EK.
+    Add keylime agent and test EK cert has been validated by the configured script.
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - CI-Tier-1
+require:
+  - yum
+  - tpm2-tools 
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
+duration: 5m
+
+
+
+

--- a/functional/ek-cert-use-ek_check_script/test.sh
+++ b/functional/ek-cert-use-ek_check_script/test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+HTTP_SERVER_PORT=8080
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+        # update /etc/keylime.conf
+        limeBackupConfig
+        # tenant, set to true to verify ek on TPM
+        rlRun "limeUpdateConf tenant require_ek_cert false"
+        # if TPM emulator is present
+        if limeTPMEmulated; then
+            # start tpm emulator
+            rlRun "limeStartTPMEmulator"
+            rlRun "limeWaitForTPMEmulator"
+            # make sure tpm2-abrmd is running
+            rlServiceStart tpm2-abrmd
+            sleep 5
+            # start ima emulator
+            rlRun "limeInstallIMAConfig"
+            rlRun "limeStartIMAEmulator"
+        fi
+
+        rlRun "cat > /var/lib/keylime/check_ek_script.sh <<_EOF
+#!/bin/sh
+echo AGENT_UUID=$AGENT_UUID
+echo ENDORSEMENT_KEY=$EK
+echo ENDORSEMENT_KEY_TPM=$EK_TPM
+echo ENDORSEMENT_KEY_CERTIFICATES=$EK_CERT
+echo PROVKEYS=$PROVKEYS
+_EOF"
+        rlRun "chown keylime:keylime /var/lib/keylime/check_ek_script.sh"
+        rlRun "chmod 500 /var/lib/keylime/check_ek_script.sh"
+        #veryfing of ek cert via own custom script
+        rlRun "limeUpdateConf tenant ek_check_script /var/lib/keylime/check_ek_script.sh"      
+        # start keylime_verifier
+        rlRun "limeStartVerifier"
+        rlRun "limeWaitForVerifier"
+        rlRun "limeStartRegistrar"
+        rlRun "limeWaitForRegistrar"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+        # create allowlist and excludelist
+        limeCreateTestLists
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent and check genuine of TPM via ek_check_script option"
+        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c update"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'" 
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        rlRun "limeStopAgent"
+        rlRun "limeStopRegistrar"
+        rlRun "limeStopVerifier"
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
+        if limeTPMEmulated; then
+            rlRun "limeStopIMAEmulator"
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
+            rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
+        fi
+        limeClearData
+        rlRun "rm -rf /var/lib/keylime/check_ek_script.sh"
+        limeRestoreConfig
+    rlPhaseEnd
+
+rlJournalEnd
+

--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/main.fmf
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/main.fmf
@@ -1,0 +1,34 @@
+summary:  Test of keylime checking of endorsement key by manually generate ek and verify against CA certs
+description: |
+    Running all services on localhost.
+    Manually generate endorsement key and add 
+    address of key to keylime.conf.
+    Starts verifier, registrar, agent.
+    Add incorrect CA certs for EK cert validation, expect agent addition to fail.
+    Add correct CA certs for EK cert validation, expect agent addition to pass.
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - CI-Tier-1
+require:
+  - yum
+  - tpm2-tools 
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
+duration: 5m
+enabled: true
+adjust:
+  - when: distro == rhel-8 or distro = centos-stream-8
+    enabled: false
+    because: swtpm is not rhel-8 and CentOS-Stream-8
+
+
+

--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+CERTDIR=/var/lib/keylime/tpm_cert_store
+CACERTDIR=/var/lib/swtpm-localca
+PASSWORD_TPM=abc123
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+        # update /etc/keylime.conf
+        limeBackupConfig       
+        # if TPM emulator is presentzz
+        if limeTPMEmulated; then
+            # start tpm emulator
+            rlRun "limeStartTPMEmulator"
+            rlRun "limeWaitForTPMEmulator"
+            # make sure tpm2-abrmd is running
+            rlServiceStart tpm2-abrmd
+            sleep 5
+            # start ima emulator
+            rlRun "limeInstallIMAConfig"
+            rlRun "limeStartIMAEmulator"
+        else
+            rlDie "Test work only when TPM is emulated."
+        fi
+        #show persistent ek
+        rlRun "tpm2_getcap handles-persistent"
+        # changes authorization values for TPM objects
+        rlRun "tpm2_changeauth -c o $PASSWORD_TPM"
+        rlRun "tpm2_changeauth -c e $PASSWORD_TPM"
+        #flush previous endorsement key
+        rlRun "tpm2_evictcontrol -C o -c 0x81010001 -P $PASSWORD_TPM"
+        #manually create endorsement key from cryptographic primitives on TPM
+        rlRun "tpm2_createek -P $PASSWORD_TPM -w $PASSWORD_TPM -c 0x81010001 -G rsa"
+        # set address to which ek use
+        rlRun "limeUpdateConf cloud_agent ek_handle 0x81010001"
+        # tenant, set to true to verify ek on TPM
+        rlRun "limeUpdateConf tenant require_ek_cert true" 
+        #configure tpm_ownerpassword    
+        rlRun "limeUpdateConf cloud_agent tpm_ownerpassword $PASSWORD_TPM"
+        # start keylime_verifier
+        rlRun "limeStartVerifier"
+        rlRun "limeWaitForVerifier"
+        rlRun "limeStartRegistrar"
+        rlRun "limeWaitForRegistrar"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+        # create allowlist and excludelist
+        limeCreateTestLists
+        # creating dir, where will be store CA cert for veryfi genuine of TPM 
+        rlRun "mkdir -p $CERTDIR"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Fail keylime agent and verify fail of checking EK cert"
+        # create empty CA, which fail the checking of EK cert
+        rlRun "touch $CERTDIR/swtpm-localca-rootca-cert.pem $CERTDIR/issuercert.pem $CERTDIR/bundle.pem"
+        # expected to fail
+        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c update" 1 
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent and verify genuine of TPM via EK cert"
+        rlRun "rm -rf $CERTDIR/*"
+        # how to obtain local CA cert and how setup https://github-wiki-see.page/m/stefanberger/swtpm/wiki/Certificates-created-by-swtpm_setup
+        # cp CA cert to dir, where keylime verify genuine of TPM
+        rlRun "cp $CACERTDIR/swtpm-localca-rootca-cert.pem $CERTDIR"
+        rlRun "cp $CACERTDIR/issuercert.pem $CERTDIR"
+        rlRun "cat $CACERTDIR/issuercert.pem $CACERTDIR/swtpm-localca-rootca-cert.pem > bundle.pem"
+        rlRun "cp bundle.pem $CERTDIR"
+        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c update"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'" 
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        rlRun "limeStopAgent"
+        rlRun "limeStopRegistrar"
+        rlRun "limeStopVerifier"
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
+        rlRun "limeStopIMAEmulator"
+        limeLogfileSubmit $(limeIMAEmulatorLogfile)
+        rlRun "limeStopTPMEmulator"
+        rlServiceRestore tpm2-abrmd
+        limeClearData
+        limeRestoreConfig
+    rlPhaseEnd
+
+rlJournalEnd
+

--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -30,6 +30,8 @@ discover:
    - /functional/basic-attestation-without-mtls
    - /functional/basic-attestation-with-unpriviledged-agent
    - /functional/basic-attestation-with-ima-signatures
+   - /functional/ek-cert-use-ek_check_script
+   - /functional/ek-cert-use-ek_handle-custom-ca_certs   
    - /functional/keylime_tenant-commands-on-localhost
    - /functional/measured-boot-swtpm-sanity
 


### PR DESCRIPTION
Scenarios verify genuine of TPM via validating EK cert.
First of these new scenarios is related with verify
EK cert against CA certs. This test used own generated endorsement key. Second scenario verify genuine of TPM by custom script.

Fix issue #105