### PR TITLE
Add /setup/configure_python_unbuffered_for_keylime

### DIFF
--- a/plans/basic-attestation-without-revocation.fmf
+++ b/plans/basic-attestation-without-revocation.fmf
@@ -12,6 +12,7 @@ prepare:
 discover:
   how: fmf
   test: 
+   - /setup/configure_python_unbuffered_for_keylime
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime
    - /setup/configure_kernel_ima_module/ima_policy_signing

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -15,6 +15,7 @@ prepare:
 discover:
   how: fmf
   test: 
+   - /setup/configure_python_unbuffered_for_keylime
    - /setup/configure_tpm_emulator
    # change IMA policy to simple and run one attestation scenario
    # this is to utilize also a different parser

--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -21,6 +21,7 @@ adjust:
 discover:
   how: fmf
   test:
+   - /setup/configure_python_unbuffered_for_keylime
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime
    - /setup/install_upstream_rust_keylime

--- a/plans/upstream-keylime-tests-github-ci.fmf
+++ b/plans/upstream-keylime-tests-github-ci.fmf
@@ -9,6 +9,7 @@ prepare:
 discover:
   how: fmf
   test: 
+   - /setup/configure_python_unbuffered_for_keylime
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime
    - /setup/enable_keylime_coverage

--- a/setup/configure_python_unbuffered_for_keylime/main.fmf
+++ b/setup/configure_python_unbuffered_for_keylime/main.fmf
@@ -1,0 +1,9 @@
+summary: Disables buffering for Python keylime services
+description: Adds unit file snippet setting PYTHONUNBUFFERED=1 for Python keylime services
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+duration: 1m
+enabled: true

--- a/setup/configure_python_unbuffered_for_keylime/test.sh
+++ b/setup/configure_python_unbuffered_for_keylime/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+
+    rlPhaseStartSetup
+        # for more info see
+        # https://unix.stackexchange.com/questions/505146/getting-systemd-service-logs-faster-from-my-service
+        for SERVICE in verifier registrar agent; do
+            rlRun "cat > /etc/systemd/system/keylime_${SERVICE}.service.d/30-unbuffer.conf <<_EOF
+[Service]
+Environment=\"PYTHONUNBUFFERED=1\"
+_EOF"
+        done
+        rlRun "systemctl daemon-reload"
+    rlPhaseEnd
+
+rlJournalEnd

--- a/setup/configure_python_unbuffered_for_keylime/test.sh
+++ b/setup/configure_python_unbuffered_for_keylime/test.sh
@@ -8,6 +8,7 @@ rlJournalStart
         # for more info see
         # https://unix.stackexchange.com/questions/505146/getting-systemd-service-logs-faster-from-my-service
         for SERVICE in verifier registrar agent; do
+            rlRun "mkdir -p /etc/systemd/system/keylime_${SERVICE}.service.d/"
             rlRun "cat > /etc/systemd/system/keylime_${SERVICE}.service.d/30-unbuffer.conf <<_EOF
 [Service]
 Environment=\"PYTHONUNBUFFERED=1\"


### PR DESCRIPTION
Sometimes there are test failures caused by the absence of a log
message in a service log, however the same message can be seen
in a log at the end of a test. Looks like a buffering problem.
This setup task sets PYTHONUNBUFFERED=1 for keylime services
as described at
https://unix.stackexchange.com/questions/505146/getting-systemd-service-logs-faster-from-my-service