### PR TITLE
Add to ek_check_script scenario fail phase

### DIFF
--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlAssertRpm keylime
         # update /etc/keylime.conf
         limeBackupConfig       
-        # if TPM emulator is presentzz
+        # if TPM emulator is present
         if limeTPMEmulated; then
             # start tpm emulator
             rlRun "limeStartTPMEmulator"


### PR DESCRIPTION
Add to ek_check_script scenario phase, where validating
of script failed and keylime tenant cannot add agent.
Assert env variables related with endorsement key.
Fix typo in ek_handle-custom-ca_certs.