### PR TITLE
Specify ima_canonical_fmt kernel boot parameter

### DIFF
--- a/setup/configure_kernel_ima_module/test.sh
+++ b/setup/configure_kernel_ima_module/test.sh
@@ -16,9 +16,10 @@ rlJournalStart
     rlPhaseStartSetup "pre-reboot phase"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
         rlRun "grubby --info DEFAULT | grep '^args'"
-        rlRun "grubby --update-kernel DEFAULT --args 'ima_appraise=${IMA_APPRAISE} ima_policy=${IMA_POLICY} ima_template=${IMA_TEMPLATE}'"
+        rlRun "grubby --update-kernel DEFAULT --args 'ima_appraise=${IMA_APPRAISE} ima_canonical_fmt ima_policy=${IMA_POLICY} ima_template=${IMA_TEMPLATE}'"
         rlRun -s "grubby --info DEFAULT | grep '^args'"
         rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
+        rlAssertGrep "ima_canonical_fmt" $rlRun_LOG
         rlAssertGrep "ima_policy=${IMA_POLICY}" $rlRun_LOG
         rlAssertGrep "ima_template=${IMA_TEMPLATE}" $rlRun_LOG
         # on s390x run zipl to make change done through grubby effective
@@ -42,6 +43,7 @@ rlJournalStart
     rlPhaseStartTest "post-reboot IMA test"
         rlRun -s "cat /proc/cmdline"
         rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
+        rlAssertGrep "ima_canonical_fmt" $rlRun_LOG
         rlAssertGrep "ima_policy=${IMA_POLICY}" $rlRun_LOG
         rlAssertGrep "ima_template=${IMA_TEMPLATE}" $rlRun_LOG
         rlRun "rm $COOKIE"


### PR DESCRIPTION
Otherwise the template hash is calculated over fields in platform
native format, which confuses IMA emulator on big-endian systems.

Signed-off-by: Daiki Ueno <dueno@redhat.com>