### PR TITLE
Disable test on s390x

### DIFF
--- a/functional/measured-boot-swtpm-sanity/main.fmf
+++ b/functional/measured-boot-swtpm-sanity/main.fmf
@@ -33,6 +33,9 @@ adjust:
   - when: swtpm is not defined or swtpm != yes
     enabled: false
     because: This tests works only with SWTPM emulator
+  - when: arch == s390x
+    enabled: false
+    because: Measured boot not functioning on s390x
   - when: distro == rhel-8 or distro = centos-stream-8
     enabled: false
     because: RHEL-8 has old tpm2-tools


### PR DESCRIPTION
Some of the required packages (tss) are not available on s390x.