### PR TITLE
Add agent and faked_measured_boot_log context

### DIFF
--- a/functional/measured-boot-swtpm-sanity/main.fmf
+++ b/functional/measured-boot-swtpm-sanity/main.fmf
@@ -39,3 +39,9 @@ adjust:
   - when: distro == rhel-8 or distro = centos-stream-8
     enabled: false
     because: RHEL-8 has old tpm2-tools
+  - when: agent == rust and faked_measured_boot_log is not defined
+    enabled: false
+    because: For Rust agent we are not able to fake measuredboot log during runtime
+  - when: agent == rust and faked_measured_boot_log == false
+    enabled: false
+    because: For Rust agent we are not able to fake measuredboot log during runtime

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,3 +1,5 @@
 # define context to filter out all test requiring TPM device
 context:
   swtpm: yes
+  agent: python
+  faked_measured_boot_log: true

--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -4,6 +4,9 @@ summary:
 environment:
   TPM_BINARY_MEASUREMENTS: /var/tmp/binary_bios_measurements
 
+context+:
+  agent: rust
+
 prepare:
   how: shell
   script:


### PR DESCRIPTION
functional/measured-boot-swtpm-sanity requires modified agent that reads measured boot log from a different location. For Python agent we can set it on the system but for the Rust agent we need to do it during compilation. By setting the proper context we can control if the test will be enabled or disabled in a test plan.
This is important for testing of distribution packages that were compiled without this hack. 