### PR TITLE
Keep only necessary configuration files in Multihost/basic-attestation

### DIFF
--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -106,7 +106,7 @@ Verifier() {
         rlRun "limeUpdateConf verifier trusted_client_ca '[\"cacert.pem\"]'"
         rlRun "limeUpdateConf verifier server_cert verifier-cert.pem"
         rlRun "limeUpdateConf verifier server_key verifier-key.pem"
-	rlRun "limeUpdateConf verifier client_cert verifier-client-cert.pem"
+        rlRun "limeUpdateConf verifier client_cert verifier-client-cert.pem"
         rlRun "limeUpdateConf verifier client_key verifier-client-key.pem"
         rlRun "limeUpdateConf revocations zmq_ip ${VERIFIER_IP}"
         rlRun "limeUpdateConf verifier client_key ${CERTDIR}/verifier-client-key.pem"
@@ -117,6 +117,11 @@ Verifier() {
 
         # change UUID just for sure so it is different from Agent
         rlRun "limeUpdateConf agent uuid d432fbb3-d2f1-4a97-9ef7-75bd81c22222"
+
+        # Delete other components configuration files
+        for comp in agent registrar tenant; do
+            rlRun "rm -rf /etc/keylime/$comp.conf*"
+        done
 
         # start keylime_verifier
         rlRun "limeStartVerifier"
@@ -168,6 +173,11 @@ Registrar() {
 
         # change UUID just for sure so it is different from Agent
         rlRun "limeUpdateConf agent uuid d432fbb3-d2f1-4a97-9ef7-75bd81c11111"
+
+        # Delete other components configuration files
+        for comp in agent verifier tenant; do
+            rlRun "rm -rf /etc/keylime/$comp.conf*"
+        done
 
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
@@ -224,16 +234,22 @@ Agent() {
         rlRun "limeUpdateConf tenant client_key ${CERTDIR}/tenant-key.pem"
 
         # configure agent
+        rlRun "limeUpdateConf agent tls_dir ${CERTDIR}"
         rlRun "limeUpdateConf agent ip ${AGENT_IP}"
         rlRun "limeUpdateConf agent contact_ip ${AGENT_IP}"
         rlRun "limeUpdateConf agent registrar_ip ${REGISTRAR_IP}"
-        rlRun "limeUpdateConf agent trusted_client_ca '[\"${CERTDIR}/cacert.pem\"]'"
+        rlRun "limeUpdateConf agent trusted_client_ca '[\"cacert.pem\"]'"
         rlRun "limeUpdateConf agent server_key agent-key.pem"
         rlRun "limeUpdateConf agent server_cert agent-cert.pem"
 
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf agent enable_revocation_notifications False"
         fi
+
+        # Delete other components configuration files
+        for comp in verifier registrar; do
+            rlRun "rm -rf /etc/keylime/$comp.conf*"
+        done
 
         # if TPM emulator is present
         if limeTPMEmulated; then
@@ -356,10 +372,11 @@ Agent2() {
         rlRun "limeUpdateConf general receive_revocation_ip ${VERIFIER_IP}"
 
         # configure agent
+        rlRun "limeUpdateConf agent tls_dir ${CERTDIR}"
         rlRun "limeUpdateConf agent ip ${AGENT2_IP}"
         rlRun "limeUpdateConf agent contact_ip ${AGENT2_IP}"
         rlRun "limeUpdateConf agent registrar_ip ${REGISTRAR_IP}"
-        rlRun "limeUpdateConf agent trusted_client_ca '[\"${CERTDIR}/cacert.pem\"]'"
+        rlRun "limeUpdateConf agent trusted_client_ca '[\"cacert.pem\"]'"
 
         # change UUID just for sure so it is different from Agent
         rlRun "limeUpdateConf agent uuid ${AGENT2_ID}"
@@ -369,6 +386,11 @@ Agent2() {
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf agent enable_revocation_notifications False"
         fi
+
+        # Delete other components configuration files
+        for comp in verifier tenant registrar; do
+            rlRun "rm -rf /etc/keylime/$comp.conf*"
+        done
 
         # if TPM emulator is present
         if limeTPMEmulated; then

--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -159,7 +159,7 @@ Registrar() {
         id keylime && rlRun "chown -R keylime.keylime ${CERTDIR}"
 
         # common configuration goes here
-        rlRun "limeUpdateConf general receive_revocation_ip ${REGISTRAR_IP}"
+        rlRun "limeUpdateConf agent revocation_notification_ip ${VERIFIER_IP}"
 
         # configure registrar
         rlRun "limeUpdateConf registrar ip ${REGISTRAR_IP}"
@@ -217,7 +217,7 @@ Agent() {
         id keylime && rlRun "chown -R keylime.keylime ${SECUREDIR}"
 
         # common configuration goes here
-        rlRun "limeUpdateConf general receive_revocation_ip ${VERIFIER_IP}"
+        rlRun "limeUpdateConf agent revocation_notification_ip ${VERIFIER_IP}"
 
         # configure tenant
         rlRun "limeUpdateConf tenant registrar_ip ${REGISTRAR_IP}"
@@ -369,7 +369,7 @@ Agent2() {
         id keylime && rlRun "chown -R keylime.keylime ${SECUREDIR}"
 
         # common configuration goes here
-        rlRun "limeUpdateConf general receive_revocation_ip ${VERIFIER_IP}"
+        rlRun "limeUpdateConf agent revocation_notification_ip ${VERIFIER_IP}"
 
         # configure agent
         rlRun "limeUpdateConf agent tls_dir ${CERTDIR}"


### PR DESCRIPTION
Remove the unnecessary configuration files for the other components in each machine.

Also fix the revocation configuration and simplify the TLS configuration in the agent by using the `tls_dir` option