### PR TITLE
Use non default ports

### DIFF
--- a/functional/keylime-non-default-ports/main.fmf
+++ b/functional/keylime-non-default-ports/main.fmf
@@ -1,0 +1,27 @@
+summary:  Test of keylime which using non default ports
+description: |
+    Change ports used by keylime services to non default ports.
+    Running all services on localhost.
+    Starts verifier, registrar, agent.
+    Add keylime agent.
+    Fail keylime agent and run revocation actions.
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - CI-Tier-1
+require:
+  - yum
+  - tpm2-tools
+recommend:
+  - keylime
+  - keylime-verifier
+  - keylime-registrar
+  - python3-keylime-agent
+  - keylime-tenant
+  - keylime-tools
+duration: 5m
+
+

--- a/functional/keylime-non-default-ports/payload-module/action_list
+++ b/functional/keylime-non-default-ports/payload-module/action_list
@@ -1,0 +1,1 @@
+local_action_modify_payload

--- a/functional/keylime-non-default-ports/payload-module/autorun.sh
+++ b/functional/keylime-non-default-ports/payload-module/autorun.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp test_payload_file /var/tmp/

--- a/functional/keylime-non-default-ports/payload-module/local_action_modify_payload.py
+++ b/functional/keylime-non-default-ports/payload-module/local_action_modify_payload.py
@@ -1,0 +1,21 @@
+import os
+import ast
+import keylime.secure_mount as secure_mount
+from keylime import keylime_logging
+from keylime import ca_util
+from keylime import config
+
+logger = keylime_logging.init_logging("local_action_rm_ssh")
+
+async def execute(event):
+    if event.get("type") != "revocation":
+        return
+
+    # load up my own cert
+    event_uuid = event.get("agent_id", "my")
+    my_uuid = config.get('agent', 'uuid')
+    logger.info("A node in the network has been compromised: %s", event["ip"])
+    logger.info("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))
+    # is this revocation meant for me?
+    if my_uuid == event_uuid:
+        os.remove("/var/tmp/test_payload_file")

--- a/functional/keylime-non-default-ports/payload-module/test_payload_file
+++ b/functional/keylime-non-default-ports/payload-module/test_payload_file
@@ -1,0 +1,1 @@
+test payload

--- a/functional/keylime-non-default-ports/payload-script/action_list
+++ b/functional/keylime-non-default-ports/payload-script/action_list
@@ -1,0 +1,1 @@
+local_action_modify_payload.py

--- a/functional/keylime-non-default-ports/payload-script/autorun.sh
+++ b/functional/keylime-non-default-ports/payload-script/autorun.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp test_payload_file /var/tmp/

--- a/functional/keylime-non-default-ports/payload-script/local_action_modify_payload.py
+++ b/functional/keylime-non-default-ports/payload-script/local_action_modify_payload.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import json
+from keylime import config
+
+json_file = sys.argv[1]
+with open(json_file, 'r') as f:
+    input_json = json.load(f)
+
+if input_json.get("type", "") != "revocation":
+    sys.exit(0)
+
+event_uuid = input_json.get("agent_id", "event_uuid")
+event_ip = input_json.get("ip", "event_ip")
+my_uuid = config.get('agent', 'uuid').strip('\"')
+
+print("A node in the network has been compromised:", event_ip)
+print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))
+
+# is this revocation meant for me?
+if my_uuid == event_uuid:
+    os.remove("/var/tmp/test_payload_file")

--- a/functional/keylime-non-default-ports/payload-script/test_payload_file
+++ b/functional/keylime-non-default-ports/payload-script/test_payload_file
@@ -1,0 +1,1 @@
+test payload

--- a/functional/keylime-non-default-ports/test.sh
+++ b/functional/keylime-non-default-ports/test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# set REVOCATION_NOTIFIER=zeromq to use the zeromq notifier
+[ -n "$REVOCATION_NOTIFIER" ] || REVOCATION_NOTIFIER=agent
+HTTP_SERVER_PORT=8080
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+
+        # update /etc/keylime.conf
+        limeBackupConfig
+        # verifier
+        rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\",\"webhook\"]'"
+        rlRun "limeUpdateConf revocations webhook_url http://localhost:${HTTP_SERVER_PORT}"
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
+        fi
+        # tenant
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        # agent
+        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "limeUpdateConf agent enable_revocation_notifications false"
+        fi
+        # if TPM emulator is present
+        if limeTPMEmulated; then
+            # start tpm emulator
+            rlRun "limeStartTPMEmulator"
+            rlRun "limeWaitForTPMEmulator"
+            # make sure tpm2-abrmd is running
+            rlServiceStart tpm2-abrmd
+            sleep 5
+            # start ima emulator
+            rlRun "limeInstallIMAConfig"
+            rlRun "limeStartIMAEmulator"
+        fi
+        sleep 5
+        #set non default ports
+        #default port 9002
+        rlRun "limeUpdateConf agent port 19002"
+        rlRun "limeUpdateConf agent contact_port 19002"
+        # default port 8890
+        rlRun "limeUpdateConf agent registrar_port 18890"
+        rlRun "limeUpdateConf registrar port 18890"
+        #default port 8992
+        rlRun "limeUpdateConf agent receive_revocation_port 18992"
+        rlRun "limeUpdateConf verifier zmq_port 18992"
+        # default port 8891 
+        rlRun "limeUpdateConf tenant registrar_port 18891"
+        rlRun "limeUpdateConf verifier registrar_port 18891"
+        rlRun "limeUpdateConf registrar tls_port 18891"
+        # default port 8881
+        rlRun "limeUpdateConf verifier port 18881"
+        rlRun "limeUpdateConf tenant verifier_port 18881"
+        rlRun "limeStartVerifier"
+        rlRun "limeWaitForVerifier 18881"
+        rlRun "limeStartRegistrar"
+        rlRun "limeWaitForRegistrar 18890"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+        # create allowlist and excludelist
+        limeCreateTestLists
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent"
+        REVOCATION_SCRIPT_TYPE=$( limeGetRevocationScriptType )
+        rlRun "cat > script.expect <<_EOF
+set timeout 20
+spawn keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --verify --allowlist allowlist.txt --exclude excludelist.txt --include payload-${REVOCATION_SCRIPT_TYPE} --cert default -c add
+expect \"Please enter the password to decrypt your keystore:\"
+send \"keylime\n\"
+expect eof
+_EOF"
+        rlRun "expect script.expect"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
+        rlWaitForFile /var/tmp/test_payload_file -t 30 -d 1  # we may need to wait for it to appear a bit
+        ls -l /var/tmp/test_payload_file
+        rlAssertExists /var/tmp/test_payload_file
+    rlPhaseEnd
+
+    rlPhaseStartTest "Fail keylime agent - revocation actions"
+        TESTDIR=`limeCreateTestDir`
+        rlRun "echo -e '#!/bin/bash\necho boom' > $TESTDIR/keylime-bad-script.sh && chmod a+x $TESTDIR/keylime-bad-script.sh"
+        rlRun "$TESTDIR/keylime-bad-script.sh"
+        rlRun "rlWaitForCmd 'tail \$(limeVerifierLogfile) | grep -q \"Agent $AGENT_ID failed\"' -m 10 -d 1 -t 10"
+        rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
+        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
+            rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: 127.0.0.1\"' -m 10 -d 1 -t 10"
+            rlRun "tail -20 $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
+            rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: 127.0.0.1'"
+            rlAssertNotExists /var/tmp/test_payload_file
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        rlRun "rm -f /var/tmp/test_payload_file"
+        rlRun "limeStopAgent"
+        rlRun "limeStopRegistrar"
+        rlRun "limeStopVerifier"
+        limeLogfileSubmit $(limeVerifierLogfile)
+        limeLogfileSubmit $(limeRegistrarLogfile)
+        limeLogfileSubmit $(limeAgentLogfile)
+        if limeTPMEmulated; then
+            rlRun "limeStopIMAEmulator"
+            limeLogfileSubmit $(limeIMAEmulatorLogfile)
+            rlRun "limeStopTPMEmulator"
+            rlServiceRestore tpm2-abrmd
+        fi
+        limeClearData
+        limeRestoreConfig
+        limeExtendNextExcludelist $TESTDIR
+    rlPhaseEnd
+
+rlJournalEnd
+


### PR DESCRIPTION
Keylime mainly use default ports set in
configuration file. Set non default ports
and check if keylime work on basic
functionality properly.

#130 