### PR TITLE
Adapt the tests for the new rust agent configuration format

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -184,7 +184,7 @@ function limeUpdateConf() {
   local KEY=$2
   local VALUE=$3
   local SED_OPTIONS=$4
-  local FILES="/etc/keylime-agent.conf $( find /etc/keylime -name '*.conf' )"
+  local FILES="$( find /etc/keylime -name '*.conf' )"
   local MODIFIED
 
   for FILE in ${FILES}; do
@@ -259,7 +259,7 @@ Returns 0 when the initialization was successfull, non-zero otherwise.
 
 limeBackupConfig() {
 
-    rlFileBackup --clean --namespace limeConf --missing-ok /etc/keylime-agent.conf /etc/keylime /etc/ima/ima-policy
+    rlFileBackup --clean --namespace limeConf --missing-ok /etc/keylime/agent.conf /etc/keylime /etc/ima/ima-policy
 
 }
 

--- a/functional/basic-attestation-on-localhost/payload-script/local_action_modify_payload.py
+++ b/functional/basic-attestation-on-localhost/payload-script/local_action_modify_payload.py
@@ -14,7 +14,7 @@ if input_json.get("type", "") != "revocation":
 
 event_uuid = input_json.get("agent_id", "event_uuid")
 event_ip = input_json.get("ip", "event_ip")
-my_uuid = config.get('agent', 'uuid')
+my_uuid = config.get('agent', 'uuid').strip('\"')
 
 print("A node in the network has been compromised:", event_ip)
 print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -26,13 +26,8 @@ rlJournalStart
         # tenant
         rlRun "limeUpdateConf tenant require_ek_cert False"
         # agent
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            if limeIsPythonAgent; then
-                rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications False"
-            else
-                rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications False"
-            fi
+            rlRun "limeUpdateConf agent enable_revocation_notifications false"
         fi
         # if TPM emulator is present
         if limeTPMEmulated; then

--- a/functional/basic-attestation-with-custom-certificates/payload-script/local_action_modify_payload.py
+++ b/functional/basic-attestation-with-custom-certificates/payload-script/local_action_modify_payload.py
@@ -14,7 +14,7 @@ if input_json.get("type", "") != "revocation":
 
 event_uuid = input_json.get("agent_id", "event_uuid")
 event_ip = input_json.get("ip", "event_ip")
-my_uuid = config.get('agent', 'uuid')
+my_uuid = config.get('agent', 'uuid').strip('\"')
 
 print("A node in the network has been compromised:", event_ip)
 print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))

--- a/functional/basic-attestation-with-custom-certificates/test.sh
+++ b/functional/basic-attestation-with-custom-certificates/test.sh
@@ -56,7 +56,6 @@ rlJournalStart
 
         # update /etc/keylime.conf
         limeBackupConfig
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
         # verifier
         rlRun "limeUpdateConf verifier check_client_cert True"
         rlRun "limeUpdateConf verifier tls_dir $CERTDIR"
@@ -67,11 +66,7 @@ rlJournalStart
         rlRun "limeUpdateConf verifier client_cert ${CERTDIR}/verifier-client-cert.pem"
         rlRun "limeUpdateConf verifier client_key ${CERTDIR}/verifier-client-key.pem"
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\",\"webhook\"]'"
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications True"
-        else
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications True"
-        fi
+        rlRun "limeUpdateConf agent enable_revocation_notifications true"
         rlRun "limeUpdateConf revocations webhook_url https://localhost:${SSL_SERVER_PORT}"
         # tenant
         rlRun "limeUpdateConf tenant require_ek_cert False"
@@ -87,19 +82,15 @@ rlJournalStart
         rlRun "limeUpdateConf registrar server_key registrar-key.pem"
         # agent
         if limeIsPythonAgent; then
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} trusted_client_ca '[\"${CERTDIR}/cacert.pem\"]'"
+            rlRun "limeUpdateConf agent trusted_client_ca '[\"${CERTDIR}/cacert.pem\"]'"
         else
-            rlRun "limeUpdateConf cloud_agent keylime_ca ${CERTDIR}/cacert.pem"
-            rlRun "limeUpdateConf cloud_agent rsa_keyname agent-key.pem"
-            rlRun "limeUpdateConf cloud_agent mtls_cert agent-cert.pem"
+            rlRun "limeUpdateConf agent trusted_client_ca '\"${CERTDIR}/cacert.pem\"'"
+            rlRun "limeUpdateConf agent server_key '\"agent-key.pem\"'"
+            rlRun "limeUpdateConf agent server_cert '\"agent-cert.pem\"'"
         fi
         if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
             rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
-            if limeIsPythonAgent; then
-                rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications False"
-            else
-                rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications False"
-            fi
+            rlRun "limeUpdateConf agent enable_revocation_notifications false"
         fi
         # if TPM emulator is present
         if limeTPMEmulated; then

--- a/functional/basic-attestation-with-unpriviledged-agent/payload-script/local_action_modify_payload.py
+++ b/functional/basic-attestation-with-unpriviledged-agent/payload-script/local_action_modify_payload.py
@@ -14,7 +14,7 @@ if input_json.get("type", "") != "revocation":
 
 event_uuid = input_json.get("agent_id", "event_uuid")
 event_ip = input_json.get("ip", "event_ip")
-my_uuid = config.get('agent', 'uuid')
+my_uuid = config.get('agent', 'uuid').strip('\"')
 
 print("A node in the network has been compromised:", event_ip)
 print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))

--- a/functional/basic-attestation-without-mtls/payload-script/local_action_modify_payload.py
+++ b/functional/basic-attestation-without-mtls/payload-script/local_action_modify_payload.py
@@ -14,7 +14,7 @@ if input_json.get("type", "") != "revocation":
 
 event_uuid = input_json.get("agent_id", "event_uuid")
 event_ip = input_json.get("ip", "event_ip")
-my_uuid = config.get('agent', 'uuid')
+my_uuid = config.get('agent', 'uuid').strip('\"')
 
 print("A node in the network has been compromised:", event_ip)
 print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))

--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
         rlAssertRpm keylime
         # update /etc/keylime.conf
-        limeBackupConfig       
+        limeBackupConfig
         # if TPM emulator is present
         if limeTPMEmulated; then
             # start tpm emulator
@@ -39,11 +39,15 @@ rlJournalStart
         rlRun "tpm2_createek -P $PASSWORD_TPM -w $PASSWORD_TPM -c 0x81010001 -G rsa"
         # tenant, set to true to verify ek on TPM
         rlRun "limeUpdateConf tenant require_ek_cert true" 
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
         # set address to which ek use
-        rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} ek_handle 0x81010001"
-        #configure tpm_ownerpassword    
-        rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} tpm_ownerpassword $PASSWORD_TPM"
+        if limeIsPythonAgent; then
+            rlRun "limeUpdateConf agent ek_handle 0x81010001"
+            rlRun "limeUpdateConf agent tpm_ownerpassword $PASSWORD_TPM"
+        else
+            rlRun "limeUpdateConf agent ek_handle '\"0x81010001\"'"
+            rlRun "limeUpdateConf agent tpm_ownerpassword '\"$PASSWORD_TPM\"'"
+        fi
+        #configure tpm_ownerpassword
         # start keylime_verifier
         rlRun "limeStartVerifier"
         rlRun "limeWaitForVerifier"

--- a/functional/install-rpm-with-ima-signature/test.sh
+++ b/functional/install-rpm-with-ima-signature/test.sh
@@ -23,12 +23,7 @@ rlJournalStart
         rlRun "limeUpdateConf tenant require_ek_cert False"
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
         rlRun "limeUpdateConf verifier quote_interval 2"
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications False"
-        else
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications False"
-        fi
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
 
         # if TPM emulator is present
         if limeTPMEmulated; then

--- a/functional/measured-boot-policy-sanity/test.sh
+++ b/functional/measured-boot-policy-sanity/test.sh
@@ -16,12 +16,7 @@ rlJournalStart
         rlRun "limeUpdateConf tenant require_ek_cert False"
         rlRun "limeUpdateConf verifier measured_boot_policy_name accept-all"
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications False"
-        else
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications False"
-        fi
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
         # start keylime_verifier
         rlRun "limeStartVerifier"
         rlRun "limeWaitForVerifier"

--- a/functional/measured-boot-swtpm-sanity/test.sh
+++ b/functional/measured-boot-swtpm-sanity/test.sh
@@ -39,12 +39,7 @@ rlJournalStart
         rlRun "limeUpdateConf tenant require_ek_cert False"
         rlRun "limeUpdateConf verifier measured_boot_policy_name accept-all"
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
-        limeIsPythonAgent && AGENT_CONFIG_SECTION=agent || AGENT_CONFIG_SECTION=cloud_agent
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} enable_revocation_notifications False"
-        else
-            rlRun "limeUpdateConf ${AGENT_CONFIG_SECTION} listen_notifications False"
-        fi
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
         # start keylime_verifier
         rlRun "limeStartVerifier"
         rlRun "limeWaitForVerifier"

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -4,6 +4,9 @@
 
 # define RUST_IMA_EMULATOR variable to install also rust IMA emulator
 
+[ -n "${RUST_KEYLIME_UPSTREAM_URL}" ] || RUST_KEYLIME_UPSTREAM_URL="https://github.com/keylime/rust-keylime.git"
+[ -n "${RUST_KEYLIME_UPSTREAM_BRANCH}" ] || RUST_KEYLIME_UPSTREAM_BRANCH="master"
+
 rlJournalStart
 
     rlPhaseStartSetup "Build and install rust-keylime bits"
@@ -11,7 +14,7 @@ rlJournalStart
             rlLogInfo "Compiling rust-keylime bits from /var/tmp/rust-keylime_sources"
         else
             rlLogInfo "Compiling rust-keylime from cloned upstream repo"
-            rlRun "git clone https://github.com/keylime/rust-keylime.git /var/tmp/rust-keylime_sources"
+            rlRun "git clone -b ${RUST_KEYLIME_UPSTREAM_BRANCH} ${RUST_KEYLIME_UPSTREAM_URL} /var/tmp/rust-keylime_sources"
         fi
         rlRun "pushd /var/tmp/rust-keylime_sources"
 

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -28,13 +28,17 @@ rlJournalStart
             rlRun "cp target/debug/keylime_ima_emulator /usr/local/bin/keylime_ima_emulator"
         fi
         if [ -f keylime-agent.conf ]; then
-            [ -f /etc/keylime-agent.conf ] && rlRun "mv /etc/keylime-agent.conf /etc/keylime-agent.conf.backup$$"
-            rlRun "cp keylime-agent.conf /etc/keylime-agent.conf"
-            rlRun "chown keylime.keylime /etc/keylime-agent.conf && chmod 400 /etc/keylime-agent.conf"
+            mkdir -p /etc/keylime
+            [ -f /etc/keylime/agent.conf ] && rlRun "mv /etc/keylime/agent.conf /etc/keylime/agent.conf.backup$$"
+            rlRun "cp keylime-agent.conf /etc/keylime/agent.conf"
+            rlRun "chown keylime.keylime /etc/keylime/agent.conf && chmod 400 /etc/keylime/agent.conf"
         fi
 
         # configure TPM to use sha256
-        rlRun "sed -i 's/^tpm_hash_alg =.*/tpm_hash_alg = \"sha256\"/' /etc/keylime-agent.conf"
+        rlRun 'cat > /etc/keylime/agent.conf.d/tpm_hash_alg.conf <<_EOF
+[agent]
+tpm_hash_alg = "sha256"
+_EOF'
 
         # Install shim.py to allow running python actions
         # This should be removed once https://github.com/keylime/rust-keylime/issues/325 is fixed

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
             rlLogInfo "Compiling rust-keylime bits from /var/tmp/rust-keylime_sources"
         else
             rlLogInfo "Compiling rust-keylime from cloned upstream repo"
-            rlRun "rm -rf rust-keylime && git clone https://github.com/keylime/rust-keylime.git /var/tmp/rust-keylime_sources"
+            rlRun "git clone https://github.com/keylime/rust-keylime.git /var/tmp/rust-keylime_sources"
         fi
         rlRun "pushd /var/tmp/rust-keylime_sources"
 
@@ -34,7 +34,7 @@ rlJournalStart
         fi
 
         # configure TPM to use sha256
-        rlRun "sed -i 's/^tpm_hash_alg =.*/tpm_hash_alg = sha256/' /etc/keylime-agent.conf"
+        rlRun "sed -i 's/^tpm_hash_alg =.*/tpm_hash_alg = \"sha256\"/' /etc/keylime-agent.conf"
 
         # Install shim.py to allow running python actions
         # This should be removed once https://github.com/keylime/rust-keylime/issues/325 is fixed


### PR DESCRIPTION
Modify the tests to be compatible with the TOML format used in the rust agent. The main differences are:

- Booleans: on TOML format they are case sensitive. Accepted values are `true` and `false`
- Strings: on TOML format they need to be double quoted.

These changes should be compatible with INI format.

This branch is temporarily used for testing the PR:
https://github.com/keylime/rust-keylime/pull/449