### PR TITLE
install_upstream_rust_keylime: require clang-devel

### DIFF
--- a/setup/install_upstream_rust_keylime/main.fmf
+++ b/setup/install_upstream_rust_keylime/main.fmf
@@ -17,6 +17,7 @@ require:
  - tpm2-tss-devel
  - zeromq-devel
  - libarchive-devel
+ - clang-devel
 duration: 20m
 enabled: true
 extra-nitrate: TC#0613570


### PR DESCRIPTION
Adding the features "generate-bindings" to tss-esapi will enable the compilation to new architectures (PPC, S390X, etc), but will drag a new devel time dependency: bindgen.  This requires clang-devel to generate the Rust stubs to the ESAPI libraries.

Signed-off-by: Alberto Planas <aplanas@suse.com>