### PR TITLE
Inject AVC SELinux checking into beakerlib phases

### DIFF
--- a/setup/configure_tpm_emulator/swtpm_permissive.te
+++ b/setup/configure_tpm_emulator/swtpm_permissive.te
@@ -4,6 +4,8 @@ type swtpm_t;
 type swtpm_exec_t;
 type tcsd_var_lib_t;
 type unreserved_port_t;
+type var_lib_t;
+type init_t;
 }
 permissive swtpm_t;
 
@@ -13,3 +15,7 @@ dontaudit swtpm_t self:tcp_socket { accept listen };
 dontaudit swtpm_t tcsd_var_lib_t:dir { add_name remove_name write };
 dontaudit swtpm_t tcsd_var_lib_t:file { create getattr lock open read rename setattr unlink write };
 dontaudit swtpm_t unreserved_port_t:tcp_socket name_bind;
+dontaudit swtpm_t var_lib_t:dir { add_name remove_name write };
+dontaudit swtpm_t var_lib_t:file { create getattr lock open read rename setattr unlink write };
+
+dontaudit init_t swtpm_exec_t:file { execute execute_no_trans map open read };

--- a/setup/inject_SELinux_AVC_check/main.fmf
+++ b/setup/inject_SELinux_AVC_check/main.fmf
@@ -1,0 +1,17 @@
+summary: Inject AVC SELinux checking into beakerlib phases
+description: |
+        Inject into beakerlib functions rlPhaseStartTest, rlPhaseStartSetup setting timestamp, 
+        and to rlPhaseEnd checking AVC based on timestamp set before. Unset timestamp variable 
+        in rlPhaseStartCleanup due to unecessary checking of AVC's in clean up phase.
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+- keylime
+test: ./test.sh
+tag:
+ - setup
+framework: beakerlib
+require:
+ - audit
+duration: 5m
+enabled: true
+

--- a/setup/inject_SELinux_AVC_check/test.sh
+++ b/setup/inject_SELinux_AVC_check/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+BEAKERLIB_SCRIPT=/usr/share/beakerlib/logging.sh
+
+rlJournalStart
+
+    rlPhaseStartTest
+        rlLogInfo "Injecting the test code into rlPhaseStartTest"
+        rlRun "cp $BEAKERLIB_SCRIPT $BEAKERLIB_SCRIPT.pre_injection_backup.$$" 0 "Making backup of $BEAKERLIB_SCRIPT"
+        if grep -q "__INTERNAL_TIMESTAMP_AVC" $BEAKERLIB_SCRIPT; then
+            rlRun "echo 'It was already injected into' $BEAKERLIB_SCRIPT"
+        else
+            rlRun "sed -i '/rlPhaseStart()/a\    __INTERNAL_TIMESTAMP_AVC=\`LC_ALL=en_US.UTF-8 date \"+%x %T\"\`\n    export __INTERNAL_TIMESTAMP_AVC\n' $BEAKERLIB_SCRIPT"
+            rlRun "sed -i '/^rlPhaseEnd()/a\    echo\n    echo \":: Test phase SELinux AVC denials since :: \$__INTERNAL_TIMESTAMP_AVC:\"\n    ausearch -m AVC -ts \$__INTERNAL_TIMESTAMP_AVC --input-logs && rlFail \"Found SELinux AVC denials within a test phase!\"' $BEAKERLIB_SCRIPT"
+        fi
+        #check status of the SELinux policy
+        rlRun "sestatus"
+    rlPhaseEnd
+
+rlJournalEnd


### PR DESCRIPTION
New setup scenario, which inject checking of AVC denials into beakerlib phases.