### PR TITLE
Draft: Do not run upstream tests as root

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,3 +2,8 @@ context:
   swtpm: yes
   agent: python
   faked_measured_boot_log: true
+
+environment:
+  KEYLIME_UPSTREAM_URL: "https://github.com/ansasaki/keylime.git"
+  KEYLIME_UPSTREAM_BRANCH: "non_destructive_test"
+

--- a/upstream/run_keylime_tests/test.sh
+++ b/upstream/run_keylime_tests/test.sh
@@ -20,7 +20,6 @@ rlJournalStart
         rlRun "rlFileBackup --missing-ok /var/lib/keylime"
         limeBackupConfig
         # update keylime configuration
-        rlRun "limeUpdateConf agent run_as root:root"
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\"]'"
         # need to adjust file permissions since we are running keylime as root (for now)
         rlRun "rm -f /var/log/keylime/*"


### PR DESCRIPTION
The goal is to make the tests compatible with https://github.com/keylime/keylime/pull/1132 in which the upstream tests are not required to be executed as root anymore.