### PR TITLE
Added support for AVC_ERROR variable

### DIFF
--- a/setup/inject_SELinux_AVC_check/test.sh
+++ b/setup/inject_SELinux_AVC_check/test.sh
@@ -9,12 +9,32 @@ rlJournalStart
     rlPhaseStartTest
         rlLogInfo "Injecting the test code into rlPhaseStartTest"
         rlRun "cp $BEAKERLIB_SCRIPT $BEAKERLIB_SCRIPT.pre_injection_backup.$$" 0 "Making backup of $BEAKERLIB_SCRIPT"
+
         if grep -q "__INTERNAL_TIMESTAMP_AVC" $BEAKERLIB_SCRIPT; then
-            rlRun "echo 'It was already injected into' $BEAKERLIB_SCRIPT"
+            rlRun "echo 'AVC check has been already injected into' $BEAKERLIB_SCRIPT"
         else
-            rlRun "sed -i '/rlPhaseStart()/a\    __INTERNAL_TIMESTAMP_AVC=\`LC_ALL=en_US.UTF-8 date \"+%x %T\"\`\n    export __INTERNAL_TIMESTAMP_AVC\n' $BEAKERLIB_SCRIPT"
-            rlRun "sed -i '/^rlPhaseEnd()/a\    echo\n    echo \":: Test phase SELinux AVC denials since :: \$__INTERNAL_TIMESTAMP_AVC:\"\n    ausearch -m AVC -ts \$__INTERNAL_TIMESTAMP_AVC --input-logs && rlFail \"Found SELinux AVC denials within a test phase!\"' $BEAKERLIB_SCRIPT"
+
+            # modify rlPhaseStart()
+            CODE=$(cat <<_EOF
+__INTERNAL_TIMESTAMP_AVC=\`LC_ALL=en_US.UTF-8 date \"+%x %T\"\`; \
+export __INTERNAL_TIMESTAMP_AVC;
+_EOF
+)
+            rlRun "sed -i '/rlPhaseStart()/a\ ${CODE}' $BEAKERLIB_SCRIPT"
+            grep -A 3 '^rlPhaseStart()' $BEAKERLIB_SCRIPT
+
+            # modify rlPhaseEnd()
+            CODE=$(cat <<_EOF
+if [[ \${AVC_ERROR} != *"no_avc_check"* ]]; then \
+echo ":: Test phase SELinux AVC denials since test phase start:: \${__INTERNAL_TIMESTAMP_AVC}:"; \
+ausearch -m AVC -ts \${__INTERNAL_TIMESTAMP_AVC} --input-logs && rlFail "Found SELinux AVC denials within a test phase!"; \
+fi
+_EOF
+)
+            rlRun "sed -i '/^rlPhaseEnd()/a\ ${CODE}' $BEAKERLIB_SCRIPT"
+            grep -A 5 '^rlPhaseEnd()' $BEAKERLIB_SCRIPT
         fi
+
         #check status of the SELinux policy
         rlRun "sestatus"
     rlPhaseEnd


### PR DESCRIPTION
by exporting `AVC_ERROR=no_avc_check` once can disable SELinux AVC check inside a test or a test phase.