### PR TITLE
Narrow test dependencies on keylime RPM

### DIFF
--- a/Library/test-helpers/main.fmf
+++ b/Library/test-helpers/main.fmf
@@ -6,7 +6,6 @@ test: ./runtest.sh
 framework: beakerlib
 require:
  - openssl
-recommend:
 duration: 5m
 enabled: true
 adjust:

--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -23,11 +23,6 @@ require:
   - wget
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 10m
 enabled: true
 extra-nitrate: TC#0611986

--- a/functional/basic-attestation-on-localhost/main.fmf
+++ b/functional/basic-attestation-on-localhost/main.fmf
@@ -21,11 +21,6 @@ require:
   - nmap-ncat
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 enabled: true
 extra-nitrate: TC#0613885

--- a/functional/basic-attestation-with-custom-certificates/main.fmf
+++ b/functional/basic-attestation-with-custom-certificates/main.fmf
@@ -23,11 +23,6 @@ require:
 - nmap-ncat
 recommend:
 - keylime
-- keylime-verifier
-- keylime-registrar
-- python3-keylime-agent
-- keylime-tenant
-- keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0611725

--- a/functional/basic-attestation-with-ima-signatures/main.fmf
+++ b/functional/basic-attestation-with-ima-signatures/main.fmf
@@ -18,13 +18,8 @@ require:
   - attr
   - ima-evm-utils
 recommend:
-  - pinentry-tty
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
+  - pinentry-tty
 duration: 5m
 enabled: true
 adjust:

--- a/functional/basic-attestation-with-unpriviledged-agent/main.fmf
+++ b/functional/basic-attestation-with-unpriviledged-agent/main.fmf
@@ -15,11 +15,6 @@ require:
   - expect
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 10m
 enabled: true
 extra-nitrate: TC#0613074

--- a/functional/basic-attestation-without-mtls/main.fmf
+++ b/functional/basic-attestation-without-mtls/main.fmf
@@ -24,11 +24,6 @@ require:
   - expect
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 10m
 enabled: true
 extra-nitrate: TC#0613576

--- a/functional/db-mariadb-sanity-on-localhost/main.fmf
+++ b/functional/db-mariadb-sanity-on-localhost/main.fmf
@@ -18,11 +18,6 @@ require:
   - tpm2-tools
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 enabled: true
 extra-nitrate: TC#0613122

--- a/functional/db-mysql-sanity-on-localhost/main.fmf
+++ b/functional/db-mysql-sanity-on-localhost/main.fmf
@@ -20,11 +20,6 @@ require:
   - tpm2-tools
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0613124

--- a/functional/db-postgresql-sanity-on-localhost/main.fmf
+++ b/functional/db-postgresql-sanity-on-localhost/main.fmf
@@ -19,11 +19,6 @@ require:
   - tpm2-tools
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 enabled: true
 extra-nitrate: TC#0613123

--- a/functional/ek-cert-use-ek_check_script/main.fmf
+++ b/functional/ek-cert-use-ek_check_script/main.fmf
@@ -17,10 +17,5 @@ require:
   - tpm2-tools 
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 extra-nitrate: TC#0614117

--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/main.fmf
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/main.fmf
@@ -18,11 +18,6 @@ require:
   - tpm2-tools 
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 enabled: true
 adjust:

--- a/functional/install-rpm-with-ima-signature/main.fmf
+++ b/functional/install-rpm-with-ima-signature/main.fmf
@@ -30,11 +30,6 @@ require:
   - pinentry
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 adjust:
   - when: distro <= fedora-36

--- a/functional/keylime-non-default-ports/main.fmf
+++ b/functional/keylime-non-default-ports/main.fmf
@@ -17,11 +17,6 @@ require:
   - tpm2-tools
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 
 

--- a/functional/keylime_tenant-commands-on-localhost/main.fmf
+++ b/functional/keylime_tenant-commands-on-localhost/main.fmf
@@ -14,11 +14,6 @@ require:
   - yum
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0613125

--- a/functional/keylime_tenant-ima-signature-sanity/main.fmf
+++ b/functional/keylime_tenant-ima-signature-sanity/main.fmf
@@ -20,13 +20,8 @@ require:
   - yum
   - tpm2-tools
 recommend:
-  - pinentry-tty
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
+  - pinentry-tty
 duration: 10m
 enabled: true
 adjust:

--- a/functional/measured-boot-policy-sanity/main.fmf
+++ b/functional/measured-boot-policy-sanity/main.fmf
@@ -16,13 +16,8 @@ require:
 - tpm2-tools
 - mokutil
 recommend:
-- efivar-libs
 - keylime
-- keylime-verifier
-- keylime-registrar
-- python3-keylime-agent
-- keylime-tenant
-- keylime-tools
+- efivar-libs
 duration: 5m
 enabled: true
 extra-nitrate: TC#0613891

--- a/functional/measured-boot-swtpm-sanity/main.fmf
+++ b/functional/measured-boot-swtpm-sanity/main.fmf
@@ -19,13 +19,8 @@ require:
 - tss2
 - tpm2-tss
 recommend:
-- efivar-libs
 - keylime
-- keylime-verifier
-- keylime-registrar
-- python3-keylime-agent
-- keylime-tenant
-- keylime-tools
+- efivar-libs
 duration: 5m
 enabled: true
 extra-nitrate: TC#0613892

--- a/functional/tenant-allowlist-sanity/main.fmf
+++ b/functional/tenant-allowlist-sanity/main.fmf
@@ -13,11 +13,6 @@ require:
   - gnupg2
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0613107

--- a/functional/tpm_policy-sanity-on-localhost/main.fmf
+++ b/functional/tpm_policy-sanity-on-localhost/main.fmf
@@ -17,11 +17,6 @@ require:
   - tpm2-tools
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612863

--- a/functional/use-multiple-ima-sign-verification-keys/main.fmf
+++ b/functional/use-multiple-ima-sign-verification-keys/main.fmf
@@ -21,11 +21,6 @@ require:
   - ima-evm-utils
 recommend:
   - keylime
-  - keylime-verifier
-  - keylime-registrar
-  - python3-keylime-agent
-  - keylime-tenant
-  - keylime-tools
 duration: 5m
 adjust:
   - when: distro == rhel-8 or distro = centos-stream-8

--- a/setup/install_upstream_keylime/keylime.spec
+++ b/setup/install_upstream_keylime/keylime.spec
@@ -5,7 +5,6 @@ Summary:	Dummy package preventing keylime RPM installation
 License:	GPLv2+	
 BuildArch:  noarch
 Provides: keylime-base
-Provides: keylime-tools
 Provides: keylime-verifier
 Provides: keylime-registrar
 Provides: keylime-tenant

--- a/upstream/run_keylime_tests/main.fmf
+++ b/upstream/run_keylime_tests/main.fmf
@@ -13,11 +13,6 @@ require:
 - python3-dbus
 recommend:
 - keylime
-- keylime-verifier
-- keylime-registrar
-- python3-keylime-agent
-- keylime-tenant
-- keylime-tools
 duration: 15m
 enabled: true
 extra-nitrate: TC#0613571


### PR DESCRIPTION
`keylime-tools` is no longer being built and requiring it in tests can accidentally pull in old keylime bits.