### PR TITLE
Extend test time for few tests

### DIFF
--- a/setup/configure_default_revocation_notifier/main.fmf
+++ b/setup/configure_default_revocation_notifier/main.fmf
@@ -7,5 +7,5 @@ test: ./test.sh
 tag:
   - setup
 framework: beakerlib
-duration: 1m
+duration: 3m
 enabled: true

--- a/setup/configure_kernel_ima_module/main.fmf
+++ b/setup/configure_kernel_ima_module/main.fmf
@@ -11,7 +11,7 @@ require:
 - grubby
 - tpm2-tools
 - openssl
-duration: 10m
+duration: 15m
 enabled: true
 adjust:
   - when: distro == rhel-8 or distro = centos-stream-8

--- a/setup/enable_keylime_debug_messages/main.fmf
+++ b/setup/enable_keylime_debug_messages/main.fmf
@@ -7,5 +7,5 @@ test: ./test.sh
 tag:
   - setup
 framework: beakerlib
-duration: 1m
+duration: 3m
 enabled: true


### PR DESCRIPTION
I have observed some test aborts in CI which I believe are caused by too small test time.
This PR increases test time for some tests I have seen aborting.