### PR TITLE
Add initial version of ref.fmf file

### DIFF
--- a/.tmt/ref.fmf
+++ b/.tmt/ref.fmf
@@ -1,0 +1,15 @@
+ref: main
+
+adjust:
+ - when: distro = centos-stream-9
+   ref: rhel-9-main
+   continue: false
+ - when: distro = rhel-9.1
+   ref: rhel-9.1.0
+   continue: false
+ - when: distro = rhel-9
+   ref: rhel-9-main
+   continue: false
+ - when: distro = fedora
+   ref: fedora-main
+   continue: false

--- a/plans/basic-attestation-without-revocation.fmf
+++ b/plans/basic-attestation-without-revocation.fmf
@@ -13,6 +13,7 @@ prepare:
 
 discover:
   how: fmf
+  ref: main
   test: 
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -23,6 +23,7 @@ prepare:
 
 discover:
   how: fmf
+  ref: main
   test: 
    - /setup/configure_tpm_emulator
    # change IMA policy to simple and run one attestation scenario

--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -25,6 +25,7 @@ adjust:
 
 discover:
   how: fmf
+  ref: main
   test:
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime

--- a/plans/upstream-keylime-tests-github-ci.fmf
+++ b/plans/upstream-keylime-tests-github-ci.fmf
@@ -10,6 +10,7 @@ prepare:
 
 discover:
   how: fmf
+  ref: main
   test: 
    - /setup/configure_tpm_emulator
    - /setup/install_upstream_keylime


### PR DESCRIPTION
Adds initial mapping of `tmt` dynamic `ref` evaluation that has been implemented in `tmt` through https://github.com/teemtee/tmt/pull/1591