### PR TITLE
Enable coverage measurement for installed keylime RPM

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1983,10 +1983,14 @@ if ! grep -q "^$PWD\$" $__INTERNAL_limeLogCurrentTest; then
 fi
 
 # prepare coveragerc file
-KEYLIMESRC=$( ls -d /usr/local/lib/python*/site-packages/keylime-*/keylime 2> /dev/null )
+if rpm -q keylime-99 &> /dev/null; then
+  KEYLIMESRC=$( ls -d /usr/local/lib/python*/site-packages/keylime-*/keylime 2> /dev/null )
+else
+  KEYLIMESRC=$( ls -d /usr/lib/python*/site-packages/keylime 2> /dev/null )
+fi
 cat > /var/tmp/limeLib/coverage/coveragerc <<_EOF
 [run]
-source = /usr/local/bin,$KEYLIMESRC
+source = /usr/bin,/usr/local/bin,$KEYLIMESRC
 parallel = True
 concurrency = multiprocessing,thread
 context = foo

--- a/setup/enable_keylime_coverage/main.fmf
+++ b/setup/enable_keylime_coverage/main.fmf
@@ -13,7 +13,6 @@ require:
   - python3-devel
   - yum
   - gcc
-recommend:
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612766

--- a/setup/enable_keylime_coverage/test.sh
+++ b/setup/enable_keylime_coverage/test.sh
@@ -16,7 +16,11 @@ rlJournalStart
 
     rlPhaseStartSetup "Modify keylime systemd unit files"
         id keylime && rlRun "chown -R keylime /var/tmp/limeLib && chmod -R g+w /var/tmp/limeLib"
-	LIBDIR=$( ls -d /usr/local/lib/python*/site-packages )
+        if rpm -q keylime-99 &> /dev/null; then
+            LIBDIR=$( ls -d /usr/local/lib/python*/site-packages )
+        else
+            LIBDIR=$( ls -d /usr/lib/python*/site-packages )
+        fi
 	rlRun "cat > ${LIBDIR}/sitecustomize.py <<_EOF
 import coverage
 coverage.process_startup()

--- a/setup/generate_coverage_report/main.fmf
+++ b/setup/generate_coverage_report/main.fmf
@@ -12,6 +12,9 @@ framework: beakerlib
 require:
   - python3-pip
   - yum
+  - git
+  - rpm-build
+  - selinux-policy-devel
 duration: 5m
 enabled: true
 extra-nitrate: TC#0612775

--- a/setup/generate_coverage_report/patchcov.py
+++ b/setup/generate_coverage_report/patchcov.py
@@ -179,7 +179,7 @@ def get_patch_coverage(patch_path, db_path):
     for row in table_context:
         if row[0] in contexts_used:
             prefix = get_test_code(row[0])
-            name = re.sub('^.*\/discover\/default\/tests', '', row[1])
+            name = re.sub('^.*\/discover\/[^/]*\/tests', '', row[1])
             print('  {}  {}'.format(prefix, name))
     print()
 


### PR DESCRIPTION
One can generate patch coverage when exporting NVR of keylime RPM to compare against, e.g.
  BASELINE_KEYLIME_RPM=keylime-6.5.1-1.el9