### PR TITLE
Add support for BASELINE_KEYLIME_RPM=previous

### DIFF
--- a/setup/generate_coverage_report/main.fmf
+++ b/setup/generate_coverage_report/main.fmf
@@ -14,6 +14,7 @@ require:
   - yum
   - git
   - rpm-build
+  - rpmdevtools
   - selinux-policy-devel
 duration: 5m
 enabled: true

--- a/setup/generate_coverage_report/test.sh
+++ b/setup/generate_coverage_report/test.sh
@@ -15,7 +15,7 @@ UPLOAD_URL=https://transfer.sh
 # PACKIT_TARGET_BRANCH - branch which PR targets
 # PACKIT_SOURCE_SHA - last commit in the PACKIT_SOURCE_BRANCH
 
-[ -n "${PATCH_COVERAGE_TRESHOLD}" ] || PATCH_COVERAGE_TRESHOLD=0
+[ -n "${PATCH_COVERAGE_THRESHOLD}" ] || PATCH_COVERAGE_THRESHOLD=0
 
 # for Packit PRs we would be uploading code coverage files unless forbidden
 [ -n "${PACKIT_SOURCE_URL}" -a -z "${UPLOAD_COVERAGE}" ] && UPLOAD_COVERAGE=1
@@ -112,7 +112,7 @@ if [ -d /var/tmp/keylime_sources ] && [ -n "${PACKIT_SOURCE_URL}" ] && [ -n "${P
         rlRun "ANCESTOR_COMMIT=\$( git merge-base ${PACKIT_SOURCE_BRANCH} PR_TARGET/${PACKIT_TARGET_BRANCH} )"
         rlRun "git diff ${ANCESTOR_COMMIT}..${PACKIT_SOURCE_SHA} > $__INTERNAL_limeCoverageDir/patch.txt"
         rlRun "popd"
-        rlRun "./patchcov.py ${__INTERNAL_limeCoverageDir}/patch.txt ${__INTERNAL_limeCoverageDir}/.coverage ${PATCH_COVERAGE_TRESHOLD}"
+        rlRun "./patchcov.py ${__INTERNAL_limeCoverageDir}/patch.txt ${__INTERNAL_limeCoverageDir}/.coverage ${PATCH_COVERAGE_THRESHOLD}"
         rlRun "rm -rf ${TmpDir}"
     rlPhaseEnd
 
@@ -160,7 +160,7 @@ elif [ -n "${BASELINE_KEYLIME_RPM}" ]; then
             rlRun "git diff > $__INTERNAL_limeCoverageDir/patch.txt"
             rlRun "popd"
             rlRun "popd"
-            rlRun "./patchcov.py ${__INTERNAL_limeCoverageDir}/patch.txt ${__INTERNAL_limeCoverageDir}/.coverage ${PATCH_COVERAGE_TRESHOLD}"
+            rlRun "./patchcov.py ${__INTERNAL_limeCoverageDir}/patch.txt ${__INTERNAL_limeCoverageDir}/.coverage ${PATCH_COVERAGE_THRESHOLD}"
             rlRun "rm -rf ${TmpDir}"
 
         fi


### PR DESCRIPTION
With `BASELINE_KEYLIME_RPM=previous` one does not have to provide specific RPM NVR but the baseline would be the previous `keylime` NVR available in a repository.