### PR TITLE
Install coverage module as a system one

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1990,7 +1990,7 @@ else
 fi
 cat > /var/tmp/limeLib/coverage/coveragerc <<_EOF
 [run]
-source = /usr/bin,/usr/local/bin,$KEYLIMESRC
+source = /usr/bin/keylime*,/usr/local/bin/keylime*,$KEYLIMESRC
 parallel = True
 concurrency = multiprocessing,thread
 context = foo


### PR DESCRIPTION
We need to make coverage module available also for distribution packages.
At the same time restrict coverage `source` to keylime scripts in `/usr/bin`