### PR TITLE
grant all on schema public

### DIFF
--- a/functional/db-postgresql-sanity-on-localhost/setup.psql
+++ b/functional/db-postgresql-sanity-on-localhost/setup.psql
@@ -3,3 +3,8 @@ create user verifier with encrypted password 'fire';
 grant all privileges on database verifierdb to verifier;
 create database registrardb;
 create user registrar with encrypted password 'regi';
+grant all privileges on database registrardb to registrar;
+\connect verifierdb;
+grant all privileges on schema public to verifier;
+\connect registrardb;
+grant all privileges on schema public to registrar;


### PR DESCRIPTION
This could fix
https://github.com/keylime/keylime/issues/1239
Some additional details about the PostgreSQL change are at
https://www.cybertec-postgresql.com/en/error-permission-denied-schema-public/