### PR TITLE
Do not remove Fedora tag repository

### DIFF
--- a/plans/basic-attestation-without-revocation.fmf
+++ b/plans/basic-attestation-without-revocation.fmf
@@ -7,7 +7,6 @@ environment+:
 prepare:
   how: shell
   script:
-   - rm -f /etc/yum.repos.d/tag-repository.repo
    - systemctl disable --now dnf-makecache.service || true
    - systemctl disable --now dnf-makecache.timer || true
 

--- a/plans/distribution-keylime-tests-github-ci.fmf
+++ b/plans/distribution-keylime-tests-github-ci.fmf
@@ -11,7 +11,6 @@ adjust:
 prepare:
   - how: shell
     script:
-     - rm -f /etc/yum.repos.d/tag-repository.repo
      - dnf config-manager --set-enabled updates-testing updates-testing-modular
      - systemctl disable --now dnf-makecache.service || true
      - systemctl disable --now dnf-makecache.timer || true

--- a/plans/rust-keylime-tests.fmf
+++ b/plans/rust-keylime-tests.fmf
@@ -10,7 +10,6 @@ context+:
 prepare:
   how: shell
   script:
-   - rm -f /etc/yum.repos.d/tag-repository.repo
    - systemctl disable --now dnf-makecache.service || true
    - systemctl disable --now dnf-makecache.timer || true
 

--- a/plans/upstream-keylime-tests-github-ci.fmf
+++ b/plans/upstream-keylime-tests-github-ci.fmf
@@ -4,7 +4,6 @@ summary:
 prepare:
   how: shell
   script:
-   - rm -f /etc/yum.repos.d/tag-repository.repo
    - systemctl disable --now dnf-makecache.service || true
    - systemctl disable --now dnf-makecache.timer || true
 


### PR DESCRIPTION
Seems that tag repo can be used even befor running a test plan to install some bits so removing it later can only lead to broken RPM dependencies.