### PR TITLE
Modify tests for keylime PR 1260

### DIFF
--- a/upstream/run_keylime_tests/test.sh
+++ b/upstream/run_keylime_tests/test.sh
@@ -36,7 +36,7 @@ rlJournalStart
             rlRun "ln -s ~/rpmbuild/BUILD/keylime* /var/tmp/keylime_sources"
         fi
         rlRun "TmpDir=\$( mktemp -d )"
-        rlRun "cp -r /var/tmp/keylime_sources/{test,test-data,tpm_cert_store,scripts} $TmpDir"
+        rlRun "cp -r /var/tmp/keylime_sources/{test,test-data,tpm_cert_store,scripts,templates} $TmpDir"
         pushd $TmpDir/test
         # if TPM emulator is present
         if limeTPMEmulated; then


### PR DESCRIPTION
This modifies the `upstream/run_keylime_tests` to include the `templates` directory used during the `test_restful.py` execution to generate the configuration files.