### PR TITLE
Update dynamic_ref with rules for Rawhide

### DIFF
--- a/.tmt/dynamic_ref.fmf
+++ b/.tmt/dynamic_ref.fmf
@@ -11,6 +11,9 @@ adjust:
  - when: distro = rhel-9
    ref: rhel-9-main
    continue: false
+ - when: distro = fedora-rawhide
+   ref: fedora-rawhide
+   continue: false
  - when: distro = fedora
    ref: fedora-main
    continue: false


### PR DESCRIPTION
Prepare mapping to the new `fedora-rawhide` branch for the future keylime rebase.