### PR TITLE
Move tpm2-abrmd start before tpm2_nvread call

### DIFF
--- a/functional/tpm-issuer-cert-using-ecc/test.sh
+++ b/functional/tpm-issuer-cert-using-ecc/test.sh
@@ -48,12 +48,12 @@ _EOF"
         # start tpm emulator
         rlRun "limeStartTPMEmulator"
         rlRun "limeWaitForTPMEmulator"
-        # print EK cert details
-        rlRun "tpm2_nvread 0x1c00002 > ekcert-rsa.der"
-        rlRun "openssl x509 -inform der -in ekcert-rsa.der -noout -text"
         # make sure tpm2-abrmd is running
         rlServiceStart tpm2-abrmd
         sleep 5
+        # print EK cert details
+        rlRun "tpm2_nvread 0x1c00002 > ekcert-rsa.der"
+        rlRun "openssl x509 -inform der -in ekcert-rsa.der -noout -text"
         # clear old data about TPM
         rlRun "rm -f /var/lib/keylime/tpmdata.yml"
         # tenant, set to true to verify ek on TPM


### PR DESCRIPTION
This should fix occasional test failures like this:
```
:: [ 13:44:15 ] :: [  BEGIN   ] :: Running 'limeStartTPMEmulator'
Redirecting to /bin/systemctl status swtpm.service
Redirecting to /bin/systemctl status swtpm.service
Redirecting to /bin/systemctl status swtpm.service
Redirecting to /bin/systemctl start swtpm.service
:: [ 13:44:15 ] :: [   LOG    ] :: rlServiceStart: Service swtpm started successfully
:: [ 13:44:15 ] :: [   PASS   ] :: Command 'limeStartTPMEmulator' (Expected 0, got 0)
:: [ 13:44:15 ] :: [  BEGIN   ] :: Running 'limeWaitForTPMEmulator'
:: [ 13:44:15 ] :: [   INFO   ] :: rlWaitForSocket: Waiting max 20s for socket `2322' to start listening
:: [ 13:44:15 ] :: [   INFO   ] :: rlWaitForSocket: Wait successful!
:: [ 13:44:15 ] :: [   PASS   ] :: Command 'limeWaitForTPMEmulator' (Expected 0, got 0)
:: [ 13:44:15 ] :: [  BEGIN   ] :: Running 'tpm2_nvread 0x1c00002 > ekcert-rsa.der'
** (process:102338): WARNING **: 13:44:15.634: Failed to create connection with service: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Object does not exist at path ?/com/intel/tss2/Tabrmd/Tcti?
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:154:tcti_from_file() Could not initialize TCTI file: tabrmd 
ERROR:tcti:src/tss2-tcti/tctildr.c:428:Tss2_TctiLdr_Initialize_Ex() Failed to instantiate TCTI 
ERROR: Could not load tcti, got: "tabrmd:bus_name=com.intel.tss2.Tabrmd"
:: [ 13:44:15 ] :: [   FAIL   ] :: Command 'tpm2_nvread 0x1c00002 > ekcert-rsa.der' (Expected 0, got 1)
```