### PR TITLE
Fix broken rust coverage measurement

### DIFF
--- a/setup/generate_upstream_rust_keylime_code_coverage/test.sh
+++ b/setup/generate_upstream_rust_keylime_code_coverage/test.sh
@@ -13,16 +13,19 @@ rlJournalStart
         #delete coverage script, in dir are mandatory only coverage files
         rlRun "pushd ${__INTERNAL_limeCoverageDir}"
         # export in format for user, gather code cover for all rust binaries
-        rlRun "grcov . --binary-path /usr/local/bin/ -s . -t html --branch --ignore-not-existing -o e2e_coverage.html"
+        rlRun "source /root/.cargo/env"
+        FILES_COUNT=$( grcov . --binary-path /usr/bin/ -s /var/tmp/rust-keylime_sources -t files --ignore-not-existing | wc -l | cut -d ' ' -f 1 )
+        rlAssertGreater "At least 50 files should have been measured ($FILES_COUNT)" $FILES_COUNT 50
+        rlRun "grcov . --binary-path /usr/bin/ -s /var/tmp/rust-keylime_sources -t html --ignore-not-existing -o e2e_coverage.html"
         # export coverage report in format compatible for codecov, gather code cover for all rust binaries
-        rlRun "grcov . --binary-path /usr/local/bin/ -s . -t lcov --branch --ignore-not-existing -o e2e_coverage.txt"
+        rlRun "grcov . --binary-path /usr/bin/ -s /var/tmp/rust-keylime_sources -t lcov --ignore-not-existing -o e2e_coverage.txt"
         # create tar file for uploading coverage file
-        rlRun "tar --create --file e2e_coverage.tar e2e_coverage.html"
-        rlFileSubmit  e2e_coverage.tar
+        rlRun "tar -czf e2e_coverage.tar.gz e2e_coverage.html"
+        rlFileSubmit  e2e_coverage.tar.gz
         rlFileSubmit e2e_coverage.txt
-        if [ -f "e2e_coverage.tar" ]; then
+        if [ -f "e2e_coverage.tar.gz" ]; then
             # upload e2e report in tar.gz
-            rlRun -s "curl --upload-file e2e_coverage.tar $UPLOAD_URL"
+            rlRun -s "curl --upload-file e2e_coverage.tar.gz $UPLOAD_URL"
             URL=$( grep -o 'https:[^"]*' $rlRun_LOG )
             rlLogInfo "HTML code coverage report is available as GZIP archive at $URL"
         fi
@@ -32,9 +35,9 @@ rlJournalStart
             URL=$( grep -o 'https:[^"]*' $rlRun_LOG )
             rlLogInfo "e2e_coverage.txt report is available at $URL"
         fi
-        if [ -f "upstream_coverage.tar" ]; then
-            #upload upstream report in .tar
-            rlRun -s "curl --upload-file upstream_coverage.tar $UPLOAD_URL"
+        if [ -f "upstream_coverage.tar.gz" ]; then
+            #upload upstream report in .tar.gz
+            rlRun -s "curl --upload-file upstream_coverage.tar.gz $UPLOAD_URL"
             URL=$( grep -o 'https:[^"]*' $rlRun_LOG )
             rlLogInfo "HTML code coverage report is available as GZIP archive at $URL"
             fi

--- a/setup/install_upstream_rust_keylime/main.fmf
+++ b/setup/install_upstream_rust_keylime/main.fmf
@@ -10,8 +10,6 @@ framework: beakerlib
 require:
  - git
  - yum
- - rust
- - cargo
  - openssl-devel
  - gcc
  - tpm2-tss-devel
@@ -19,7 +17,6 @@ require:
  - libarchive-devel
  - clang-devel
  - rpm-build
- - rust-packaging
 duration: 20m
 enabled: true
 extra-nitrate: TC#0613570

--- a/upstream/run_rust_keylime_tests/test.sh
+++ b/upstream/run_rust_keylime_tests/test.sh
@@ -38,11 +38,11 @@ rlJournalStart
         rlPhaseStartTest "Run cargo tests and measure code coverage"
             #run cargo tarpaulin code coverage
             rlRun "cargo tarpaulin -v --target-dir target/tarpaulin --workspace --exclude-files 'target/*' --ignore-panics --ignore-tests --out Xml --out Html --all-features"
-            rlRun "tar --create --file upstream_coverage.tar tarpaulin-report.html"
+            rlRun "tar -czf upstream_coverage.tar.gz tarpaulin-report.html"
             rlRun "mv cobertura.xml upstream_coverage.xml"
             rlFileSubmit upstream_coverage.xml
-            rlFileSubmit upstream_coverage.tar
-            rlRun "mv upstream_coverage.xml upstream_coverage.tar ${__INTERNAL_limeCoverageDir}"
+            rlFileSubmit upstream_coverage.tar.gz
+            rlRun "mv upstream_coverage.xml upstream_coverage.tar.gz ${__INTERNAL_limeCoverageDir}"
         rlPhaseEnd
     fi
 


### PR DESCRIPTION
This fixes broken coverage measurement due to changed filepaths and absent Rust flags. Also, always use Rustup to avoid duplicite Rust installation. 