### PR TITLE
Extend set of ignored lines in patchcov.py

### DIFF
--- a/setup/generate_coverage_report/patchcov.py
+++ b/setup/generate_coverage_report/patchcov.py
@@ -71,7 +71,7 @@ def should_ignore_line(line):
         return True
     if l.startswith('#'):
         return True
-    if l == '}' or l == '},':
+    if l in ['}', '},', ')', '),', '):']:
         return True
     return False
 


### PR DESCRIPTION
Should be backported to rhel-9-main and rhel-9.1.0