### PR TITLE
Add support for swtpm device configured using tpm_vtpm_proxy module

### DIFF
--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -257,9 +257,7 @@ Agent() {
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             limeInstallIMAConfig
             rlRun "limeStartIMAEmulator"
@@ -338,7 +336,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         rlRun "rm -f /var/tmp/test_payload_file"
@@ -406,9 +404,7 @@ Agent2() {
             # start tpm emulator
             limeStartTPMEmulator
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             limeInstallIMAConfig
             limeStartIMAEmulator
@@ -454,7 +450,7 @@ Agent2() {
         if limeTPMEmulated; then
             limeStopIMAEmulator
             limeStopTPMEmulator
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
     rlPhaseEnd

--- a/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
+++ b/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
@@ -26,9 +26,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -81,7 +79,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/agent_UUID_assignment_options/test.sh
+++ b/functional/agent_UUID_assignment_options/test.sh
@@ -20,9 +20,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -82,7 +80,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -35,7 +35,6 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
             rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -36,8 +36,7 @@ rlJournalStart
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
             # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -117,7 +116,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/basic-attestation-with-custom-certificates/test.sh
+++ b/functional/basic-attestation-with-custom-certificates/test.sh
@@ -105,9 +105,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -200,7 +198,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         rlRun "rm /etc/pki/ca-trust/source/anchors/keylime-ca.crt"

--- a/functional/basic-attestation-with-ima-signatures/test.sh
+++ b/functional/basic-attestation-with-ima-signatures/test.sh
@@ -22,9 +22,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -81,7 +79,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/basic-attestation-with-unpriviledged-agent/test.sh
+++ b/functional/basic-attestation-with-unpriviledged-agent/test.sh
@@ -31,9 +31,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -122,7 +120,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         if [ -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf ]; then

--- a/functional/basic-attestation-without-mtls/test.sh
+++ b/functional/basic-attestation-without-mtls/test.sh
@@ -28,9 +28,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -123,7 +121,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         if [ -f /etc/systemd/system/keylime_agent.service.d/20-keylime_dir.conf ]; then

--- a/functional/db-mariadb-sanity-on-localhost/test.sh
+++ b/functional/db-mariadb-sanity-on-localhost/test.sh
@@ -15,9 +15,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -71,7 +69,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         # restore files and services

--- a/functional/db-mysql-sanity-on-localhost/test.sh
+++ b/functional/db-mysql-sanity-on-localhost/test.sh
@@ -33,9 +33,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -82,7 +80,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
 

--- a/functional/db-postgresql-sanity-on-localhost/test.sh
+++ b/functional/db-postgresql-sanity-on-localhost/test.sh
@@ -14,9 +14,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -74,7 +72,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         # restore files and services

--- a/functional/durable-attestion-sanity-on-localhost/test.sh
+++ b/functional/durable-attestion-sanity-on-localhost/test.sh
@@ -47,9 +47,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -103,7 +101,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/ek-cert-use-ek_check_script/test.sh
+++ b/functional/ek-cert-use-ek_check_script/test.sh
@@ -21,9 +21,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -85,7 +83,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
@@ -19,9 +19,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -89,7 +87,7 @@ rlJournalStart
         rlRun "limeStopIMAEmulator"
         rlRun "limeStopTPMEmulator"
         limeSubmitCommonLogs
-        rlServiceRestore tpm2-abrmd
+        rlRun "limeCondStopAbrmd"
         limeClearData
         limeRestoreConfig
     rlPhaseEnd

--- a/functional/install-rpm-with-ima-signature/test.sh
+++ b/functional/install-rpm-with-ima-signature/test.sh
@@ -30,9 +30,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -142,7 +140,7 @@ EOF
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/keylime-non-default-ports/test.sh
+++ b/functional/keylime-non-default-ports/test.sh
@@ -32,9 +32,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -105,7 +103,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -17,9 +17,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -135,7 +133,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/keylime_tenant-ima-signature-sanity/test.sh
+++ b/functional/keylime_tenant-ima-signature-sanity/test.sh
@@ -21,9 +21,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -102,7 +100,7 @@ EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/measured-boot-swtpm-sanity/test.sh
+++ b/functional/measured-boot-swtpm-sanity/test.sh
@@ -16,9 +16,7 @@ rlJournalStart
         # start tpm emulator
         rlRun "limeStartTPMEmulator"
         rlRun "limeWaitForTPMEmulator"
-        # make sure tpm2-abrmd is running
-        rlServiceStart tpm2-abrmd
-        sleep 5
+        rlRun "limeCondStartAbrmd"
 
         # update config.py to use our fake  binary_bios_measurements
         # for the rust agent this is handled in the /setup/install_upstream_rust_keylime task
@@ -111,7 +109,7 @@ rlJournalStart
         rlRun "limeStopVerifier"
         rlRun "limeStopIMAEmulator"
         rlRun "limeStopTPMEmulator"
-        rlServiceRestore tpm2-abrmd
+        rlRun "limeCondStopAbrmd"
         limeSubmitCommonLogs
         limeClearData
         limeRestoreConfig

--- a/functional/service-logfiles-logging/test.sh
+++ b/functional/service-logfiles-logging/test.sh
@@ -21,9 +21,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -139,7 +137,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         rlRun "rm -rf /var/log/keylime"
         rlFileRestore

--- a/functional/tenant-runtime-policy-sanity/test.sh
+++ b/functional/tenant-runtime-policy-sanity/test.sh
@@ -21,9 +21,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -194,7 +192,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/tpm-issuer-cert-using-ecc/test.sh
+++ b/functional/tpm-issuer-cert-using-ecc/test.sh
@@ -48,9 +48,7 @@ _EOF"
         # start tpm emulator
         rlRun "limeStartTPMEmulator"
         rlRun "limeWaitForTPMEmulator"
-        # make sure tpm2-abrmd is running
-        rlServiceStart tpm2-abrmd
-        sleep 5
+        rlRun "limeCondStartAbrmd"
         # print EK cert details
         rlRun "tpm2_nvread 0x1c00002 > ekcert-rsa.der"
         rlRun "openssl x509 -inform der -in ekcert-rsa.der -noout -text"
@@ -91,7 +89,7 @@ _EOF"
         rlRun "limeStopIMAEmulator"
         limeLogfileSubmit $(limeIMAEmulatorLogfile)
         rlRun "limeStopTPMEmulator"
-        rlServiceRestore tpm2-abrmd
+        rlRun "limeCondStopAbrmd"
         rlRun "rm -rf ${KEYLIME_CERT_DIR}"
         limeClearData
         limeRestoreConfig

--- a/functional/tpm_policy-sanity-on-localhost/test.sh
+++ b/functional/tpm_policy-sanity-on-localhost/test.sh
@@ -15,9 +15,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -74,7 +72,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/functional/use-multiple-ima-sign-verification-keys/test.sh
+++ b/functional/use-multiple-ima-sign-verification-keys/test.sh
@@ -20,9 +20,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -96,7 +94,7 @@ _EOF"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/plans/upstream-keylime-swtpm-dev.fmf
+++ b/plans/upstream-keylime-swtpm-dev.fmf
@@ -1,0 +1,41 @@
+summary:
+  Tests used by Packit/TFT CI on Github to test upstream keylime
+
+environment+:
+  TPM_BINARY_MEASUREMENTS: /var/tmp/binary_bios_measurements
+  KEYLIME_RUST_CODE_COVERAGE: 1
+
+prepare:
+  - how: shell
+    script:
+     - systemctl disable --now dnf-makecache.service || true
+     - systemctl disable --now dnf-makecache.timer || true
+
+discover:
+  how: fmf
+  test: 
+   - /setup/configure_swtpm_device
+   - /setup/install_upstream_keylime
+   - /setup/install_upstream_rust_keylime
+   # change IMA policy to simple and run one attestation scenario
+   # this is to utilize also a different parser
+   - /setup/configure_kernel_ima_module/ima_policy_simple
+   - /functional/basic-attestation-on-localhost
+
+execute:
+    how: tmt
+
+adjust:
+  - when: target_PR_branch is defined and target_PR_branch != main
+    enabled: false
+    because: we want to run this plan only for PRs targeting the main branch
+
+  - when: distro != fedora-37
+    enabled: false
+
+  - when: "distro == fedora-37"
+    prepare+:
+      - how: shell
+        order: 99
+        script:
+          - yum -y downgrade tpm2-tss

--- a/setup/configure_swtpm_device/main.fmf
+++ b/setup/configure_swtpm_device/main.fmf
@@ -1,0 +1,18 @@
+summary: Configures emulated TPM device on a running system
+description: Configures emulated TPM as a device using the kernel vtpm proxy module
+contact: Karel Srot <ksrot@redhat.com>
+component:
+- keylime
+test: ./test.sh
+tag:
+- setup
+framework: beakerlib
+require:
+- yum
+- swtpm
+- swtpm-tools
+- tpm2-tss
+- tpm2-tools
+- selinux-policy-devel
+duration: 5m
+enabled: true

--- a/setup/configure_swtpm_device/swtpm_permissive.te
+++ b/setup/configure_swtpm_device/swtpm_permissive.te
@@ -1,0 +1,1 @@
+../configure_tpm_emulator/swtpm_permissive.te

--- a/setup/configure_swtpm_device/test.sh
+++ b/setup/configure_swtpm_device/test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# required swtpm service state can be passed via RUNNING variable
+# 1 = services running
+# 0 = services stop (default)
+
+[ "$RUNNING" == "1" ] || RUNNING=0
+
+# Packages list based on the TPM emulator.
+# We use ibmswtpm2 for EL8 and swtpm for the other platforms.
+TPM_EMULATOR=swtpm
+
+rlJournalStart
+
+    rlPhaseStartSetup "Install TPM emulator"
+
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlRun "echo device > $__INTERNAL_limeTmpDir/swtpm_setup"
+
+        # load the kernel module
+	rlRun "modprobe tpm_vtpm_proxy"
+        rlRun "cat > /etc/modules-load.d/tpm_vtpm_proxy.conf <<_EOF
+tpm_vtpm_proxy
+_EOF"
+        # create swtpm unit file as it doesn't exist
+        rlRun "cat > /etc/systemd/system/swtpm.service <<_EOF
+[Unit]
+Description=swtpm TPM Software emulator
+
+[Service]
+Type=simple
+ExecStartPre=/usr/bin/mkdir -p /var/lib/tpm/swtpm
+ExecStartPre=/usr/bin/swtpm_setup --tpm-state /var/lib/tpm/swtpm --createek --decryption --create-ek-cert --create-platform-cert --lock-nvram --overwrite --display --tpm2 --pcr-banks sha256
+ExecStart=/usr/bin/swtpm chardev --vtpm-proxy --tpmstate dir=/var/lib/tpm/swtpm  --tpm2
+
+[Install]
+WantedBy=multi-user.target
+_EOF"
+        rlRun "systemctl daemon-reload"
+
+        # now we need to build custom selinux module making swtpm_t a permissive domain
+        # since the policy module shipped with swtpm package doesn't seem to work
+        # see https://github.com/stefanberger/swtpm/issues/632 for more details
+        if ! semodule -l | grep -q swtpm_permissive; then
+            rlRun "make -f /usr/share/selinux/devel/Makefile swtpm_permissive.pp"
+            rlAssertExists swtpm_permissive.pp
+            rlRun "semodule -i swtpm_permissive.pp"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartSetup "Start TPM emulator"
+        rlServiceStart $TPM_EMULATOR
+        rlRun "limeWaitForTPMEmulator"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test TPM emulator"
+        rlRun -s "tpm2_pcrread"
+        rlAssertGrep "0 : 0x0000000000000000000000000000000000000000" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        if [ "$RUNNING" == "0" ]; then
+            rlServiceStop $TPM_EMULATOR
+        fi
+    rlPhaseEnd
+
+rlJournalEnd

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -21,6 +21,7 @@ rlJournalStart
     rlPhaseStartSetup "Install TPM emulator"
 
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlRun "echo socket > $__INTERNAL_limeTmpDir/swtpm_setup"
 
         TPM_EMULATOR="$(limeTPMEmulator)"
         [ "${TPM_EMULATOR}" == "ibmswtpm2" ] && TPM_PKGS="${TPM_PKGS_IBMSWTPM}" || TPM_PKGS="${TPM_PKGS_SWTPM}"

--- a/update/basic-attestation-on-localhost/test.sh
+++ b/update/basic-attestation-on-localhost/test.sh
@@ -34,9 +34,7 @@ if echo ${PHASES} | egrep -qi '(setup|all)'; then
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -96,7 +94,7 @@ if echo ${PHASES} | egrep -qi '(cleanup|all)'; then
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
         limeClearData

--- a/upstream/run_keylime_tests/test.sh
+++ b/upstream/run_keylime_tests/test.sh
@@ -43,14 +43,10 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
-        else
-            rlServiceStart tpm2-abrmd
         fi
         # prepare /var/lib/keylime/secure tmpfs if note present
         SECDIR=/var/lib/keylime/secure
@@ -111,7 +107,7 @@ rlJournalStart
         limeClearData
         limeRestoreConfig
         rlRun "rlFileRestore"
-        rlServiceRestore tpm2-abrmd
+        rlRun "limeCondStopAbrmd"
         rlRun "rm -rf $TmpDir"
     rlPhaseEnd
 

--- a/upstream/run_rust_keylime_tests/test.sh
+++ b/upstream/run_rust_keylime_tests/test.sh
@@ -16,9 +16,7 @@ rlJournalStart
             # start tpm emulator
             rlRun "limeStartTPMEmulator"
             rlRun "limeWaitForTPMEmulator"
-            # make sure tpm2-abrmd is running
-            rlServiceStart tpm2-abrmd
-            sleep 5
+            rlRun "limeCondStartAbrmd"
             # start ima emulator
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
@@ -51,7 +49,7 @@ rlJournalStart
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
-            rlServiceRestore tpm2-abrmd
+            rlRun "limeCondStopAbrmd"
         fi
     rlPhaseEnd
 


### PR DESCRIPTION
Adds a new setup task and also a test plan that utilize this setup task to illustrate the usage.