### PR TITLE
Improve container support in the main branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,7 +2,8 @@ jobs:
 - job: tests
   trigger: pull_request
   targets:
-    - fedora-stable
+    - fedora-37
+#    - fedora-all
     - centos-stream-9-x86_64
   skip_build: true
   tf_extra_params:

--- a/Library/test-helpers/Dockerfile.agent
+++ b/Library/test-helpers/Dockerfile.agent
@@ -1,2 +1,9 @@
 FROM quay.io/centos/centos:stream9
-RUN dnf install -y keylime-agent-rust util-linux-core && dnf clean all
+COPY id_*.pub /root/
+COPY lime_con_start.sh /usr/local/bin/lime_con_start
+RUN dnf install -y keylime-agent-rust util-linux-core openssh openssh-server which && \
+  dnf clean all && \
+  ssh-keygen -A && mkdir -p /root/.ssh && \
+  cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+  chmod 700 /root/.ssh/authorized_keys && \
+  chmod a+x /usr/local/bin/lime_con_start

--- a/Library/test-helpers/Dockerfile.agent
+++ b/Library/test-helpers/Dockerfile.agent
@@ -1,4 +1,2 @@
 FROM quay.io/centos/centos:stream9
 RUN dnf install -y keylime-agent-rust util-linux-core && dnf clean all
-COPY cacert.crt /var/lib/keylime/cv_ca/
-RUN chmod o+r /var/lib/keylime/cv_ca/cacert.crt

--- a/Library/test-helpers/Dockerfile.registrar
+++ b/Library/test-helpers/Dockerfile.registrar
@@ -1,2 +1,9 @@
 FROM quay.io/centos/centos:stream9
-RUN dnf install -y keylime-registrar util-linux-core && dnf clean all
+COPY id_*.pub /root/
+COPY lime_con_start.sh /usr/local/bin/lime_con_start
+RUN dnf install -y keylime-registrar openssh openssh-server which && \
+  dnf clean all && \
+  ssh-keygen -A && mkdir -p /root/.ssh && \
+  cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+  chmod 700 /root/.ssh/authorized_keys && \
+  chmod a+x /usr/local/bin/lime_con_start

--- a/Library/test-helpers/Dockerfile.systemd
+++ b/Library/test-helpers/Dockerfile.systemd
@@ -1,0 +1,9 @@
+FROM quay.io/centos/centos:stream9
+COPY id_*.pub /root/
+RUN dnf install -y systemd util-linux-core openssh openssh-server && \
+  dnf clean all && \
+  ssh-keygen -A && \
+  mkdir -p /root/.ssh && \
+  cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+  chmod 700 /root/.ssh/authorized_keys
+CMD ["/sbin/init"]

--- a/Library/test-helpers/Dockerfile.upstream.c9s
+++ b/Library/test-helpers/Dockerfile.upstream.c9s
@@ -1,0 +1,11 @@
+FROM quay.io/centos/centos:stream9
+COPY lime_con_start.sh /usr/local/bin/lime_con_start
+COPY lime_con_install_upstream.sh /usr/local/bin/lime_con_install_upstream
+COPY id_*.pub /root/
+RUN chmod a+x /usr/local/bin/lime_con_* && \
+    mkdir -p /mnt/keylime_sources && \
+    cp -r /mnt/keylime_sources /var/tmp/keylime_sources && \
+    /usr/local/bin/lime_con_install_upstream && \
+    ssh-keygen -A && mkdir -p /root/.ssh && \
+    cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+    chmod 700 /root/.ssh/authorized_keys

--- a/Library/test-helpers/Dockerfile.verifier
+++ b/Library/test-helpers/Dockerfile.verifier
@@ -1,2 +1,9 @@
 FROM quay.io/centos/centos:stream9
-RUN dnf install -y keylime-verifier util-linux-core && dnf clean all
+COPY id_*.pub /root/
+COPY lime_con_start.sh /usr/local/bin/lime_con_start
+RUN dnf install -y keylime-verifier openssh openssh-server which && \
+  dnf clean all && \
+  ssh-keygen -A && mkdir -p /root/.ssh && \
+  cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+  chmod 700 /root/.ssh/authorized_keys && \
+  chmod a+x /usr/local/bin/lime_con_start

--- a/Library/test-helpers/lime_con_install_upstream.sh
+++ b/Library/test-helpers/lime_con_install_upstream.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# enable epel repo
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+# install build requires for C9S
+yum -y install which openssh openssh-server git python3-lark-parser python3-packaging python3-typing-extensions python3-pip python3-pyyaml python3-tornado python3-requests python3-sqlalchemy python3-alembic python3-psutil python3-gnupg python3-cryptography libselinux-python3 python3-pyasn1 python3-zmq python3-pyasn1-modules python3-jsonschema tpm2-tools
+
+# if keylime_sources are not present, clone the repo
+if [ ! -f /var/tmp/keylime_sources/setup.py ]; then
+    rm -rf /var/tmp/keylime_sources
+    git clone https://github.com/keylime/keylime.git /var/tmp/keylime_sources
+fi
+
+# install upstream keylime
+pushd /var/tmp/keylime_sources
+mkdir -p /etc/keylime && chmod 700 /etc/keylime
+python3 setup.py install
+
+# create directory structure in /etc/keylime and copy config files there
+for comp in "verifier" "tenant" "registrar" "ca" "logging"; do
+    mkdir -p /etc/keylime/$comp.conf.d
+    cp -n config/$comp.conf /etc/keylime/
+done
+
+# install scripts to /usr/share/keylime
+mkdir -p /usr/share/keylime
+cp -r scripts /usr/share/keylime/
+
+# enable rust agent COPR repo and install agent
+cat > /etc/yum.repos.d/copr-rust-keylime-master.repo <<_EOF
+[copr-rust-keylime-master]
+name=Copr repo for keylime-rust-keylime-master owned by packit
+baseurl=https://download.copr.fedorainfracloud.org/results/packit/keylime-rust-keylime-master/fedora-\$releasever-\$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/packit/keylime-rust-keylime-master/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+priority=1
+_EOF
+sed -i 's|keylime-rust-keylime-master/fedora|keylime-rust-keylime-master/centos-stream|' /etc/yum.repos.d/copr-rust-keylime-master.repo
+yum -y install keylime-agent-rust
+curl -o /etc/keylime/keylime-agent.conf https://raw.githubusercontent.com/keylime/rust-keylime/master/keylime-agent.conf
+mkdir -p /etc/systemd/system/keylime_agent.service.d
+mkdir -p /etc/keylime/agent.conf.d
+# configure agent to use sha256 in TPM
+cat > /etc/keylime/agent.conf.d/tpm_hash_alg.conf <<_EOF
+[agent]
+tpm_hash_alg = "sha256"
+_EOF
+
+# fix conf file ownership
+useradd keylime
+usermod -a -G tss keylime
+chown -Rv keylime:keylime /etc/keylime /var/lib/keylime
+find /etc/keylime -type f -exec chmod 400 {} \;
+find /etc/keylime -type d -exec chmod 500 {} \;
+ls -lR /etc/keylime
+popd
+
+# clean yum cache
+yum clean all

--- a/Library/test-helpers/lime_con_start.sh
+++ b/Library/test-helpers/lime_con_start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# runs sshd on a background and then runs program passed as an argument
+/usr/sbin/sshd &> /var/log/sshd &
+# copy cv_ca if mounted
+mkdir -p /mnt/cv_ca
+cp -r /mnt/cv_ca /var/lib/keylime/
+chown -R keylime:keylime /var/lib/keylime/cv_ca
+# run requested program
+RUST_LOG=keylime_agent=trace $( which $1 )

--- a/container/functional/keylime_agent_container-basic-attestation/main.fmf
+++ b/container/functional/keylime_agent_container-basic-attestation/main.fmf
@@ -23,8 +23,4 @@ recommend:
   - keylime
 duration: 10m
 enabled: true
-adjust:
-  - when: swtpm == yes
-    enabled: false
-    because: This tests needs TPM device since kernel boot
 extra-nitrate: TC#0614624

--- a/container/functional/keylime_verifier_registrar_container-basic-attestation/main.fmf
+++ b/container/functional/keylime_verifier_registrar_container-basic-attestation/main.fmf
@@ -25,8 +25,4 @@ recommend:
   - keylime
 duration: 10m
 enabled: true
-adjust:
-  - when: swtpm == yes
-    enabled: false
-    because: This tests needs TPM device since kernel boot
 extra-nitrate: TC#0614624

--- a/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
+++ b/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
@@ -7,6 +7,10 @@
 #Machine should have /dev/tpm0 or /dev/tpmrm0 device
 AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
+[ -n "$DOCKERFILE_VERIFIER" ] || DOCKERFILE_VERIFIER=Dockerfile.upstream.c9s
+[ -n "$DOCKERFILE_REGISTRAR" ] || DOCKERFILE_REGISTRAR=Dockerfile.upstream.c9s
+[ -n "$DOCKERFILE_AGENT" ] || DOCKERFILE_AGENT=Dockerfile.upstream.c9s
+
 rlJournalStart
 
     rlPhaseStartSetup "Do the keylime setup"
@@ -32,11 +36,23 @@ rlJournalStart
 
         #build verifier container
         TAG_VERIFIER="verifier_image"
-        rlRun "limeconPrepareVerifierImage ${TAG_VERIFIER}"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_VERIFIER} ${TAG_VERIFIER}"
 
         #build registrar container
         TAG_REGISTRAR="registrar_image"
-        rlRun "limeconPrepareRegistrarImage ${TAG_REGISTRAR}"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_REGISTRAR} ${TAG_REGISTRAR}"
+
+        # if TPM emulator is present
+        if limeTPMEmulated; then
+            # start tpm emulator
+            rlRun "limeStartTPMEmulator"
+            rlRun "limeWaitForTPMEmulator"
+            rlRun "limeCondStartAbrmd"
+            # start ima emulator
+            rlRun "limeInstallIMAConfig"
+            rlRun "limeStartIMAEmulator"
+        fi
+        sleep 5
 
         #mandatory for access agent containers to tpm
         rlRun "chmod o+rw /dev/tpmrm0"
@@ -65,8 +81,7 @@ rlJournalStart
         #setup of agent
         TAG_AGENT="agent_image"
         CONT_AGENT="agent_container"
-        rlRun "cp cv_ca/cacert.crt ."
-        rlRun "limeconPrepareAgentImage ${TAG_AGENT}"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_AGENT} ${TAG_AGENT}"
         rlRun "limeUpdateConf agent registrar_ip '\"$IP_REGISTRAR\"'"
         rlRun "limeconPrepareAgentConfdir $AGENT_ID $IP_AGENT confdir_$CONT_AGENT"
 
@@ -75,14 +90,14 @@ rlJournalStart
         rlRun "echo -e '#!/bin/bash\necho This is good-script1' > $TESTDIR/good-script1.sh && chmod a+x $TESTDIR/good-script1.sh"
         rlRun "echo -e '#!/bin/bash\necho This is good-script2' > $TESTDIR/good-script2.sh && chmod a+x $TESTDIR/good-script2.sh"
         # create allowlist and excludelist
-        rlRun "limeCreateTestLists ${TESTDIR}/*"
+        rlRun "limeCreateTestPolicy ${TESTDIR}/*"
 
         rlRun "limeconRunAgent $CONT_AGENT $TAG_AGENT $IP_AGENT $CONT_NETWORK_NAME $PWD/confdir_$CONT_AGENT $TESTDIR"
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
     rlPhaseEnd
 
     rlPhaseStartTest "Add keylime agent"
-        rlRun -s "keylime_tenant -v $IP_VERIFIER  -t $IP_AGENT -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c add"
+        rlRun -s "keylime_tenant -v $IP_VERIFIER  -t $IP_AGENT -u $AGENT_ID --runtime-policy policy.json -f /etc/hosts -c add"
         rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
         rlRun -s "keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
@@ -106,13 +121,16 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartCleanup "Do the keylime cleanup"
-        #possible manage function to stop it all
-        rlRun "limeconStop 'registrar_container'"
-        rlRun "limeconStop 'verifier_container'"
-        rlRun "limeconStop 'agent_container'"
+        limeconSubmitLogs
+        rlRun "limeconStop registrar_container verifier_container agent_container"
         rlRun "limeconDeleteNetwork $CONT_NETWORK_NAME"
         #set tmp resource manager permission to default state
         rlRun "chmod o-rw /dev/tpmrm0"
+        if limeTPMEmulated; then
+            rlRun "limeStopIMAEmulator"
+            rlRun "limeStopTPMEmulator"
+            rlRun "limeCondStopAbrmd"
+        fi
         limeExtendNextExcludelist $TESTDIR
         limeSubmitCommonLogs
         limeClearData

--- a/plans/upstream-keylime-all-tests.fmf
+++ b/plans/upstream-keylime-all-tests.fmf
@@ -25,8 +25,8 @@ discover:
    - /functional/basic-attestation-on-localhost
    # now change IMA policy to signing and run all tests
    - /setup/configure_kernel_ima_module/ima_policy_signing
-   - "/functional/.*"
-   - "/compatibility/.*"
+   - "^/functional/.*"
+   - "^/compatibility/.*"
    - /update/basic-attestation-on-localhost/all
    # run upstream test suite
    - /upstream/run_keylime_tests

--- a/plans/upstream-keylime-swtpm-dev.fmf
+++ b/plans/upstream-keylime-swtpm-dev.fmf
@@ -4,6 +4,9 @@ summary:
 environment+:
   TPM_BINARY_MEASUREMENTS: /var/tmp/binary_bios_measurements
   KEYLIME_RUST_CODE_COVERAGE: 1
+  DOCKERFILE_AGENT: Dockerfile.upstream.c9s
+  DOCKERFILE_VERIFIER: Dockerfile.upstream.c9s
+  DOCKERFILE_REGISTRAR: Dockerfile.upstream.c9s
 
 prepare:
   - how: shell
@@ -16,11 +19,12 @@ discover:
   test: 
    - /setup/configure_swtpm_device
    - /setup/install_upstream_keylime
-   - /setup/install_upstream_rust_keylime
+   - /setup/install_rust_keylime_from_copr
    # change IMA policy to simple and run one attestation scenario
    # this is to utilize also a different parser
    - /setup/configure_kernel_ima_module/ima_policy_simple
    - /functional/basic-attestation-on-localhost
+   - "/container/.*"
 
 execute:
     how: tmt
@@ -32,10 +36,3 @@ adjust:
 
   - when: distro != fedora-37
     enabled: false
-
-  - when: "distro == fedora-37"
-    prepare+:
-      - how: shell
-        order: 99
-        script:
-          - yum -y downgrade tpm2-tss

--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -30,6 +30,11 @@ _EOF'
         # prepare directory for drop-in adjustments
         rlRun "mkdir -p /etc/systemd/system/keylime_agent.service.d"
         rlRun "mkdir -p /etc/keylime/agent.conf.d"
+        rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
+[Service]
+Environment=\"RUST_LOG=keylime_agent=trace\"
+_EOF"
+        rlRun "systemctl daemon-reload"
     rlPhaseEnd
 
     rlPhaseStartTest "Test installed binaries"


### PR DESCRIPTION
- Adds new Dockerfile.upstream.cs9 which prepares image with the upstream keylime
- Adopts some `limecon` optimizations from the `rhel-9-main` branch
- Modifies `limecon` functions in order to reduce the number of images built during the test
- Additional `limecon` enhancements
- Existing container tests updated and enabled in one tmt plan

Although the code of `limecon` diverge from the `rhel-9-main` branch I belive it is worth it.