### PR TITLE
Define SERVERS and CLIENTS based on TMT_ROLE_ variables

### DIFF
--- a/Library/sync/lib.sh
+++ b/Library/sync/lib.sh
@@ -52,7 +52,9 @@ the library load.
 
 # we are using hardcoded paths so they are preserved due to reboots
 export __INTERNAL_syncStatusFile=/var/tmp/sync-status
-
+# export SERVERS and CLIENTS variables when defined by tmt
+[ -n "${SERVERS}" ] || export SERVERS=${TMT_ROLE_SERVERS}
+[ -n "${CLIENTS}" ] || export CLIENTS=${TMT_ROLE_CLIENTS}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Initialization / Installation


### PR DESCRIPTION
Define legacy (Beaker-like) environment variables `SERVERS` and `CLIENTS` if the respective role-based variables are defined by `tmt`. This change relates to the currently WIP multi-host test support for `tmt` developed in https://github.com/teemtee/tmt/pull/1790.