### PR TITLE
When installing from Copr, set the measured boot log location

### DIFF
--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -34,6 +34,14 @@ _EOF'
 [Service]
 Environment=\"RUST_LOG=keylime_agent=trace\"
 _EOF"
+        # If the TPM_BINARY_MEASUREMENTS env var is set, set the binary
+        # measurements location for the service
+        if [ -n "${TPM_BINARY_MEASUREMENTS}" ]; then
+            rlRun "cat > /etc/systemd/system/keylime_agent.service.d/30-measured_boot_location.conf <<_EOF
+[Service]
+Environment=\"TPM_BINARY_MEASUREMENTS=${TPM_BINARY_MEASUREMENTS}\"
+_EOF"
+        fi
         rlRun "systemctl daemon-reload"
     rlPhaseEnd
 


### PR DESCRIPTION
If the TPM_BINARY_MEASUREMENTS environment variable is set, set the
measured boot log location when installing the agent from Copr.