### PR TITLE
Add conditional to clear tpm2 cache only on machines with HW/QEMU TPM

### DIFF
--- a/setup/configure_kernel_ima_module/test.sh
+++ b/setup/configure_kernel_ima_module/test.sh
@@ -31,7 +31,7 @@ rlJournalStart
         # install IMA policy
         rlRun "limeInstallIMAConfig ${IMA_POLICY_FILE}"
         # clear TPM
-        if ! limeTPMEmulated; then
+        if ! limeTPMEmulated && [ -c /dev/tpmrm0 ]; then
             rlRun "tpm2_clear"
         fi
         # FIXME: workaround for issue https://github.com/keylime/keylime/issues/1025


### PR DESCRIPTION
IMA setup task could be used also on scenarios where is not used TPM, so tpm2_clear could be useless and just cause FAIL of setup task, added new conditional to check if task run on HW/QEMU TPM machine. 

Example of usage without TPM: [fapolicyd PR](https://github.com/RedHat-SP-Security/tests/pull/125/files#diff-c4ab242efdb76106e77b0c20a45b90bd44f8bd60e33b6bf3d41298c9d7037f8bR16)