### PR TITLE
Kill keyboxd introduced in gnupg2-2.4.1

### DIFF
--- a/functional/keylime_tenant-ima-signature-sanity/test.sh
+++ b/functional/keylime_tenant-ima-signature-sanity/test.sh
@@ -43,6 +43,7 @@ rlJournalStart
         rlRun "cp ${limeIMAPublicKey} ."
         # generate GPG key
         rlRun "gpgconf --kill gpg-agent"
+        rlRun "gpgconf --kill keyboxd"
         rlRun "export GNUPGHOME=${TmpDir}"
         rlRun "cat >gpg.script <<EOF
 %echo Generating a basic OpenPGP key


### PR DESCRIPTION
Should fix test failure we are observing on Rawhide.