### PR TITLE
Export SERVERS and CLIENTS following tmt topology

### DIFF
--- a/Library/sync/lib.sh
+++ b/Library/sync/lib.sh
@@ -52,9 +52,28 @@ the library load.
 
 # we are using hardcoded paths so they are preserved due to reboots
 export __INTERNAL_syncStatusFile=/var/tmp/sync-status
+
+# for backvards compatibility define SERVERS and CLIENTS variables using tmt topology
+if [ -n "${TMT_TOPOLOGY_SH}" -a -f ${TMT_TOPOLOGY_SH} ]; then
+    . ${TMT_TOPOLOGY_SH}
+    cat ${TMT_TOPOLOGY_SH}
+    echo
+fi
 # export SERVERS and CLIENTS variables when defined by tmt
-[ -n "${SERVERS}" ] || export SERVERS=${TMT_ROLE_SERVERS}
-[ -n "${CLIENTS}" ] || export CLIENTS=${TMT_ROLE_CLIENTS}
+if [ -z "${SERVERS}" -a -n "${TMT_ROLES[SERVERS]}" ]; then
+    export SERVERS=""
+    for SRV in ${TMT_ROLES[SERVERS]}; do
+        SERVERS="$SERVERS ${TMT_GUESTS[${SRV}.hostname]}"
+    done
+    echo "SERVERS=${SERVERS}"
+fi
+if [ -z "${CLIENTS}" -a -n "${TMT_ROLES[CLIENTS]}" ]; then
+    export CLIENTS=""
+    for SRV in ${TMT_ROLES[CLIENTS]}; do
+        CLIENTS="$CLIENTS ${TMT_GUESTS[${SRV}.hostname]}"
+    done
+    echo "CLIENTS=${CLIENTS}"
+fi
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Initialization / Installation

--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -462,16 +462,21 @@ Agent2() {
 # Common script part
 ####################
 
-# assigne custom roles using SERVERS and CLIENTS variables
-export VERIFIER=$( echo "$SERVERS $CLIENTS" | awk '{ print $1 }')
-export REGISTRAR=$( echo "$SERVERS $CLIENTS" | awk '{ print $2 }')
-export AGENT=$( echo "$SERVERS $CLIENTS" | awk '{ print $3 }')
-export AGENT2=$( echo "$SERVERS $CLIENTS" | awk '{ print $4 }')
-
 export TESTSOURCEDIR=`pwd`
 
 rlJournalStart
     rlPhaseStartSetup
+        # import keylime library
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlRun 'rlImport "./sync"' || rlDie "cannot import keylime-tests/sync library"
+        rlRun 'rlImport "openssl/certgen"' || rlDie "cannot import openssl/certgen library"
+ 
+        # assigne custom roles using SERVERS and CLIENTS variables
+        export VERIFIER=$( echo "$SERVERS $CLIENTS" | awk '{ print $1 }')
+        export REGISTRAR=$( echo "$SERVERS $CLIENTS" | awk '{ print $2 }')
+        export AGENT=$( echo "$SERVERS $CLIENTS" | awk '{ print $3 }')
+        export AGENT2=$( echo "$SERVERS $CLIENTS" | awk '{ print $4 }')
+
         MY_IP=$( hostname -I | awk '{ print $1 }' )
         [ -n "$VERIFIER" ] && export VERIFIER_IP=$( get_IP $VERIFIER )
         [ -n "$REGISTRAR" ] && export REGISTRAR_IP=$( get_IP $REGISTRAR )
@@ -487,12 +492,8 @@ rlJournalStart
         # common setup
         ###############
 
-        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
-        # import keylime library
-        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
-        rlRun 'rlImport "./sync"' || rlDie "cannot import keylime-tests/sync library"
-        rlRun 'rlImport "openssl/certgen"' || rlDie "cannot import openssl/certgen library"
         rlAssertRpm keylime
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         # backup files
         limeBackupConfig
         # load REVOCATION_SCRIPT_TYPE


### PR DESCRIPTION
`tmt` is changing the way how topology data are exported. This PR updates `sync` library so it works following `tmt` PR https://github.com/teemtee/tmt/pull/2072.