### PR TITLE
Unify .packit.yaml in the main branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,7 @@
 jobs:
 - job: tests
   trigger: pull_request
+  branch: main
   targets:
     - fedora-all
     - centos-stream-9-x86_64
@@ -10,3 +11,25 @@ jobs:
       - tmt:
           context:
             target_PR_branch: "main"
+- job: tests
+  trigger: pull_request
+  branch: rhel-9-main
+  targets:
+    - centos-stream-9-x86_64
+  skip_build: true
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            target_PR_branch: "rhel-9-main"
+- job: tests
+  trigger: pull_request
+  branch: fedora-rawhide
+  targets:
+    - fedora-rawhide-x86_64
+  skip_build: true
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            target_PR_branch: "fedora-rawhide"


### PR DESCRIPTION
Since Packit RFE https://github.com/packit/packit-service/issues/2051 implemented we can unify .packit.yaml in the main branch so we won't have to customize it when rebasing tests to rhel-9-main or fedora-rawhide branch.