### PR TITLE
Use skip_if_unavailable=False for COPR repo

### DIFF
--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
 name=Copr repo for keylime-rust-keylime-master owned by packit
 baseurl=https://download.copr.fedorainfracloud.org/results/packit/keylime-rust-keylime-master/fedora-\$releasever-\$basearch/
 type=rpm-md
-skip_if_unavailable=True
+skip_if_unavailable=False
 gpgcheck=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/packit/keylime-rust-keylime-master/pubkey.gpg
 repo_gpgcheck=0


### PR DESCRIPTION
We should make the setup task to fail when COPR repo cannot be used.