### PR TITLE
Add `jq` utility to test-helpers

### DIFF
--- a/Library/test-helpers/main.fmf
+++ b/Library/test-helpers/main.fmf
@@ -6,6 +6,7 @@ test: ./runtest.sh
 framework: beakerlib
 require:
  - openssl
+ - jq
 duration: 5m
 enabled: true
 adjust:


### PR DESCRIPTION
This is a very minimal PR, to enable further changes. The main goal here is to have `keylime_tenant` to always output JSON, and use the `jq` tool to properly parse and read status/info from the schema, rather than grep specific strings in log messages.