### PR TITLE
Allow (temporarily) exit codes 0 and 1 for `regstatus`, `cvstatus` and `add` (with incorrect PCR banks)

### DIFF
--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -63,7 +63,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "-c regstatus"
-        rlRun -s "keylime_tenant -c regstatus"
+        rlRun -s "keylime_tenant -c regstatus" 0,1
         rlAssertGrep "{\"code\": 200, \"status\": \"Agent $AGENT_ID exists on registrar 127.0.0.1 port 8891.\"" $rlRun_LOG
     rlPhaseEnd
 
@@ -105,14 +105,14 @@ rlJournalStart
 
     rlPhaseStartTest "-c regdelete"
         rlRun -s "keylime_tenant -c regdelete"
-        rlRun -s "keylime_tenant -c regstatus"
+        rlRun -s "keylime_tenant -c regstatus" 0,1
         rlAssertGrep "{\"code\": 404, \"status\": \"Agent $AGENT_ID does not exist on registrar 127.0.0.1 port 8891.\"" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "-c delete"
         rlRun -s "keylime_tenant -c delete"
         rlAssertGrep "(INFO - CV completed deletion of agent $AGENT_ID|INFO - Agent $AGENT_ID deleted from the CV)" $rlRun_LOG -E
-        rlRun -s "keylime_tenant -c cvstatus"
+        rlRun -s "keylime_tenant -c cvstatus" 0,1
         rlAssertGrep "Verifier at 127.0.0.1 with Port 8881 does not have agent $AGENT_ID" $rlRun_LOG
     rlPhaseEnd
 

--- a/functional/measured-boot-swtpm-sanity/test.sh
+++ b/functional/measured-boot-swtpm-sanity/test.sh
@@ -80,7 +80,7 @@ rlJournalStart
         # use installed create_mb_refstate from /usr/share/keylime/scripts
         rlRun "python3 /usr/share/keylime/scripts/create_mb_refstate /var/tmp/binary_bios_measurements mb_refstate2.txt"
         #rlRun "tsseventextend -tpm -if /var/tmp/binary_bios_measurements"
-        rlRun -s "keylime_tenant -u $AGENT_ID --verify --tpm_policy '{}' --runtime-policy policy.json -f /etc/hostname -c add --mb_refstate mb_refstate2.txt"
+        rlRun -s "keylime_tenant -u $AGENT_ID --verify --tpm_policy '{}' --runtime-policy policy.json -f /etc/hostname -c add --mb_refstate mb_refstate2.txt" 0,1
         rlRun "limeWaitForAgentStatus $AGENT_ID 'Tenant Quote Failed'"
         rlAssertGrep "keylime.tpm - ERROR - For PCR 0 and hash sha256 the boot event log has value '.*' but the agent .*returned '.*'" $(limeVerifierLogfile) -E
     rlPhaseEnd


### PR DESCRIPTION
Related to https://github.com/keylime/keylime/pull/1414