### PR TITLE
Disable Packit CI on Rawhide due to infra issues

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,7 @@ jobs:
   trigger: pull_request
   branch: main
   targets:
-    - fedora-all
+    - fedora-branched
     - centos-stream-9-x86_64
   skip_build: true
   tf_extra_params:


### PR DESCRIPTION
dnf5 used in Rawhide doesnt work well with the Testing Farm infrastructure and therefore we need to disable testing on Rawhide temporarily.