### PR TITLE
Improve timeouts to account for time spent in keylime_tenant

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1217,7 +1217,7 @@ limeWaitForAgentRegistration() {
     for I in `seq $TIMEOUT`; do
         keylime_tenant -c regstatus -u $UUID &> $OUTPUT
         REGSTATE=$(cat $OUTPUT | grep "^{" | jq -r ".[].operational_state")
-	if [ $REGSTATE == "Registered" ]; then
+    if [ "$REGSTATE" == "Registered" ]; then
             cat $OUTPUT
             rm $OUTPUT
             return 0


### PR DESCRIPTION
The current timeout implementation does not account for the time spent in keylime_tenant.