### PR TITLE
Improve timeouts to account for time spent in keylime_tenant

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1101,13 +1101,17 @@ limeWaitForAgentStatus() {
     [ -z "$2" ] && return 4
     [ -n "$3" ] && TIMEOUT=$3
 
+    local START=$SECONDS
     for I in `seq $TIMEOUT`; do
-        keylime_tenant -c status -u $UUID &> $OUTPUT
-	if grep -E -q "\"operational_state\": \"$STATUS\"" $OUTPUT; then
+        timeout $TIMEOUT keylime_tenant -c status -u $UUID &> $OUTPUT
+        if grep -E -q "\"operational_state\": \"$STATUS\"" $OUTPUT; then
             cat $OUTPUT
-	    rm $OUTPUT
-	    return 0
-	fi
+            rm $OUTPUT
+            return 0
+        fi
+        if [[ "$((SECONDS - START))" -ge $TIMEOUT ]]; then
+            break
+        fi
         sleep 1
     done
     cat $OUTPUT
@@ -1149,13 +1153,17 @@ limeWaitForAgentRegistration() {
     [ -z "$1" ] && return 3
     [ -n "$2" ] && TIMEOUT=$2
 
+    local START=$SECONDS
     for I in `seq $TIMEOUT`; do
-        keylime_tenant -c regstatus -u $UUID &> $OUTPUT
-	if grep -q "Agent $UUID exists on registrar" $OUTPUT; then
+        timeout $TIMEOUT keylime_tenant -c regstatus -u $UUID &> $OUTPUT
+        if grep -E -q "\"operational_state\": \"Registered\"" $OUTPUT; then
             cat $OUTPUT
-	    rm $OUTPUT
-	    return 0
-	fi
+            rm $OUTPUT
+            return 0
+        fi
+        if [[ "$((SECONDS - START))" -ge $TIMEOUT ]]; then
+            break
+        fi
         sleep 1
     done
     cat $OUTPUT

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -851,6 +851,58 @@ limeStopTPMEmulator() {
 true <<'=cut'
 =pod
 
+=head2 limeCondStartAbrmd
+
+Start tpm2-abrmd service if swtpm is configured to use socket
+
+    limeCondStartAbrmd
+
+=over
+
+=back
+
+Returns 0 when the start was successful, non-zero otherwise.
+
+=cut
+
+limeCondStartAbrmd() {
+    # do nothing if swtpm is configured as a device
+    if grep -q device $__INTERNAL_limeTmpDir/swtpm_setup &> /dev/null; then
+        rlLogInfo "Not starting tpm2-abrmd, swtpm created TPM device"
+    else
+        rlServiceStart tpm2-abrmd && sleep 5
+    fi
+}
+
+true <<'=cut'
+=pod
+
+=head2 limeCondStopAbrmd
+
+Stop tpm2-abrmd service when it is running.
+
+    limeCondStopAbrmd
+
+=over
+
+=back
+
+Returns 0 when the stop was successful, non-zero otherwise.
+
+=cut
+
+limeCondStopAbrmd() {
+    # do nothing if swtpm is configured as a device
+    if systemctl is-active tpm2-abrmd 2> /dev/null; then
+        rlServiceStop tpm2-abrmd
+    else
+        rlLogInfo "Not stopping tpm2-abrmd as it was not running."
+    fi
+}
+
+true <<'=cut'
+=pod
+
 =head2 limeCheckRemotePort
 
 Use limeCheckRemotePort to check port on specified ip adress.

--- a/setup/configure_tpm_emulator/test.sh
+++ b/setup/configure_tpm_emulator/test.sh
@@ -21,6 +21,7 @@ rlJournalStart
     rlPhaseStartSetup "Install TPM emulator"
 
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlRun "echo socket > $__INTERNAL_limeTmpDir/swtpm_setup"
 
         TPM_EMULATOR="$(limeTPMEmulator)"
         [ "${TPM_EMULATOR}" == "ibmswtpm2" ] && TPM_PKGS="${TPM_PKGS_IBMSWTPM}" || TPM_PKGS="${TPM_PKGS_SWTPM}"


### PR DESCRIPTION
Backporting 389cd7d23 from the main branch.
* Avoid error when there is no response from registrar
When the registrar does not send a response, the REGSTATE variable can be empty, causing syntax error.
* Run keylime_tenant calls under timeout
Avoid blocking on keylime_tenant calls by running under timeout. Improve timeout to account for time spent in keylime_tenant command.



---------