### PR TITLE
Fix revocation script so it won't import keylime config

### DIFF
--- a/Multihost/basic-attestation/payload-script/local_action_modify_payload.py
+++ b/Multihost/basic-attestation/payload-script/local_action_modify_payload.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import json
-from keylime import config
+import toml
 
 json_file = sys.argv[1]
 with open(json_file, 'r') as f:
@@ -14,7 +14,8 @@ if input_json.get("type", "") != "revocation":
 
 event_uuid = input_json.get("agent_id", "event_uuid")
 event_ip = input_json.get("ip", "event_ip")
-my_uuid = config.get('agent', 'uuid').strip('\"')
+with open("/etc/keylime/agent.conf", "r") as f:
+    my_uuid = toml.load(f)["agent"]["uuid"].strip('\"')
 
 print("A node in the network has been compromised:", event_ip)
 print("my UUID: %s, event UUID: %s" % (my_uuid, event_uuid))


### PR DESCRIPTION
This has been done previously for functional tests but Multihost test was omitted.