### PR TITLE
Use development C9S repos in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,6 +22,9 @@ jobs:
       - tmt:
           context:
             target_PR_branch: "rhel-9-main"
+        artifacts:
+          - type: repository-file
+            id: "https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo"
 - job: tests
   trigger: pull_request
   branch: fedora-rawhide


### PR DESCRIPTION
Commonly used CentOS Stream 9 mirrors are one week behind the main repository. Therefore let's use the main repo instead of mirrors.