### PR TITLE
Backport fixes from rhel-9-main

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,6 +22,9 @@ jobs:
       - tmt:
           context:
             target_PR_branch: "rhel-9-main"
+        artifacts:
+          - type: repository-file
+            id: "https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo"
 - job: tests
   trigger: pull_request
   branch: fedora-rawhide

--- a/plans/distribution-c9s-keylime-tests-github-ci.fmf
+++ b/plans/distribution-c9s-keylime-tests-github-ci.fmf
@@ -26,10 +26,10 @@ discover:
    # this is to utilize also a different parser
    - /setup/configure_kernel_ima_module/ima_policy_simple
    - /setup/enable_keylime_debug_messages
-   - /functional/basic-attestation-on-localhost
+   - "^/functional/basic-attestation-on-localhost"
    # now change IMA policy to signing and run all tests
    - /setup/configure_kernel_ima_module/ima_policy_signing
-   - "/functional/.*"
+   - "^/functional/.*"
 
 execute:
     how: tmt


### PR DESCRIPTION
Backport `.packit.yaml` update and distribution testplan updates from `rhel-9-main` so that they won't be lost with a future rewrite.