### PR TITLE
Enable upstream-keylime-swtpm-dev for C9S

### DIFF
--- a/plans/upstream-keylime-swtpm-dev.fmf
+++ b/plans/upstream-keylime-swtpm-dev.fmf
@@ -28,5 +28,5 @@ adjust+:
     enabled: false
     because: we want to run this plan only for PRs targeting the main branch
 
-  - when: distro != fedora-37
+  - when: distro != fedora-37 and distro != centos-stream-9
     enabled: false


### PR DESCRIPTION
vtpm_tpm_proxy module is finally available in C9S and we can start using it.