### PR TITLE
Make epel-release install always pass

### DIFF
--- a/plans/distribution-c9s-keylime-tests-github-ci.fmf
+++ b/plans/distribution-c9s-keylime-tests-github-ci.fmf
@@ -16,7 +16,7 @@ prepare+:
   - how: shell
     order: 30
     script:
-     - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+     - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
 
 discover:
   how: fmf

--- a/plans/upstream-basic-attestation-without-revocation.fmf
+++ b/plans/upstream-basic-attestation-without-revocation.fmf
@@ -28,4 +28,4 @@ adjust+:
       - how: shell
         order: 30
         script:
-         - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+         - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true

--- a/plans/upstream-keylime-all-tests.fmf
+++ b/plans/upstream-keylime-all-tests.fmf
@@ -42,7 +42,7 @@ adjust+:
       - how: shell
         order: 30
         script:
-         - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+         - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
 
   # discover step adjustments
   # disable code coverage measurement everywhere except F37 and CS9


### PR DESCRIPTION
Sometimes it happens that a test system already contains a newer version of epel-release. Weird but true.