### PR TITLE
Set keylime_port_t label for random ports use in tests

### DIFF
--- a/functional/basic-attestation-with-custom-certificates/main.fmf
+++ b/functional/basic-attestation-with-custom-certificates/main.fmf
@@ -22,6 +22,7 @@ require:
 - openssl
 - nmap-ncat
 - python3-toml
+- policycoreutils-python-utils
 recommend:
 - keylime
 duration: 15m

--- a/functional/basic-attestation-with-custom-certificates/test.sh
+++ b/functional/basic-attestation-with-custom-certificates/test.sh
@@ -17,6 +17,11 @@ rlJournalStart
         rlRun 'rlImport "certgen/certgen"' || rlDie "cannot import openssl/certgen library"
         rlAssertRpm keylime
 
+        #seting keylime_port_t label for ssl port
+        if rlIsRHEL '>=9.3' || rlIsFedora '>=38' || rlIsCentOS '>=9';then
+            rlRun "semanage port -a -t keylime_port_t -p tcp $SSL_SERVER_PORT"
+        fi
+
         # generate TLS certificates for all
         # we are going to use 4 certificates
         # verifier = webserver cert used for the verifier server

--- a/functional/keylime-non-default-ports/main.fmf
+++ b/functional/keylime-non-default-ports/main.fmf
@@ -17,6 +17,7 @@ require:
   - yum
   - tpm2-tools
   - python3-toml
+  - policycoreutils-python-utils
 recommend:
   - keylime
 duration: 5m

--- a/functional/keylime-non-default-ports/test.sh
+++ b/functional/keylime-non-default-ports/test.sh
@@ -39,6 +39,16 @@ rlJournalStart
             rlRun "limeInstallIMAConfig"
             rlRun "limeStartIMAEmulator"
         fi
+
+        #seting keylime_port_t label for non default ports
+        if rlIsRHEL '>=9.3' || rlIsFedora '>=38' || rlIsCentOS '>=9';then
+            rlRun "semanage port -a -t keylime_port_t -p tcp 19002"
+            rlRun "semanage port -a -t keylime_port_t -p tcp 18890"
+            rlRun "semanage port -a -t keylime_port_t -p tcp 18992"
+            rlRun "semanage port -a -t keylime_port_t -p tcp 18891"
+            rlRun "semanage port -a -t keylime_port_t -p tcp 18881"
+        fi
+
         sleep 5
         #set non default ports
         #default port 9002


### PR DESCRIPTION
Apply condtionally for specific version of rhel and fedoras.