### PR TITLE
Remove keylime logging on DEBUG level

### DIFF
--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -15,9 +15,6 @@ rlJournalStart
 
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # verifier
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
         # tenant

--- a/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
+++ b/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
@@ -12,9 +12,6 @@ rlJournalStart
 
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # verifier
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
         # tenant

--- a/functional/agent_UUID_assignment_options/test.sh
+++ b/functional/agent_UUID_assignment_options/test.sh
@@ -9,9 +9,6 @@ rlJournalStart
         rlAssertRpm keylime
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
 
         rlRun "limeUpdateConf tenant require_ek_cert False"
 

--- a/functional/basic-attestation-on-localhost/test.sh
+++ b/functional/basic-attestation-on-localhost/test.sh
@@ -15,9 +15,6 @@ rlJournalStart
 
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # verifier
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\",\"webhook\"]'"
         rlRun "limeUpdateConf revocations webhook_url http://localhost:${HTTP_SERVER_PORT}"

--- a/functional/durable-attestion-sanity-on-localhost/test.sh
+++ b/functional/durable-attestion-sanity-on-localhost/test.sh
@@ -28,8 +28,6 @@ rlJournalStart
         # update /etc/keylime.conf
         limeBackupConfig
         rlRun "limeUpdateConf logger_root level INFO"        
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
 
         # disable the need for ek cert for tenant
         rlRun "limeUpdateConf tenant require_ek_cert False"

--- a/functional/ek-cert-use-ek_check_script/test.sh
+++ b/functional/ek-cert-use-ek_check_script/test.sh
@@ -12,8 +12,6 @@ rlJournalStart
         rlAssertRpm keylime
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # tenant, set to true to verify ek on TPM
         rlRun "limeUpdateConf tenant require_ek_cert false"
         # if TPM emulator is present

--- a/regression/issue-1380-agent-removed-and-re-added/test.sh
+++ b/regression/issue-1380-agent-removed-and-re-added/test.sh
@@ -12,9 +12,6 @@ rlJournalStart
 
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # verifier
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
         # tenant

--- a/sanity/keylime-secure_mount/test.sh
+++ b/sanity/keylime-secure_mount/test.sh
@@ -17,9 +17,6 @@ rlJournalStart
         # update /etc/keylime.conf
         limeBackupConfig
         rlFileBackup $KEYLIME_UNIT_FILE
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # tenant
         rlRun "limeUpdateConf tenant require_ek_cert False"
         # if TPM emulator is present

--- a/update/basic-attestation-on-localhost/test.sh
+++ b/update/basic-attestation-on-localhost/test.sh
@@ -22,9 +22,6 @@ if echo ${PHASES} | egrep -qi '(setup|all)'; then
 
         # update /etc/keylime.conf
         limeBackupConfig
-        rlRun "limeUpdateConf logger_root level DEBUG"
-        rlRun "limeUpdateConf logger_keylime level DEBUG"
-        rlRun "limeUpdateConf handler_consoleHandler level DEBUG"
         # verifier
         rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\"]'"
         # tenant


### PR DESCRIPTION
Debug logging slows test execution significantly and is a root cause of various test failures. We should not be using it unless we are troubleshooting an actual problem.
