### PR TITLE
Added plan distribution-c9s-keylime-swtpm-dev.fmf

### DIFF
--- a/plans/distribution-c9s-keylime-swtpm-dev.fmf
+++ b/plans/distribution-c9s-keylime-swtpm-dev.fmf
@@ -1,0 +1,35 @@
+summary:
+  Container tests from the rhel-9-main branch
+
+context:
+  swtpm: yes
+  agent: rust
+  faked_measured_boot_log: no
+
+adjust+:
+ - when: target_PR_branch is defined and target_PR_branch != rhel-9-main
+   enabled: false
+   because: we want to run this plan only for PRs targeting the main branch
+
+environment:
+  AGENT_DOCKERFILE: Dockerfile.agent
+  VERIFIER_DOCKERFILE: Dockerfile.verifier
+  REGISTRAR_DOCKERFILE: Dockerfile.registrar
+  TENANT_DOCKERFILE: Dockerfile.tenant
+
+discover:
+  url: https://github.com/RedHat-SP-Security/keylime-tests.git
+  ref: main
+  how: fmf
+  test: 
+   # need two TPM devices
+   - /setup/configure_swtpm_device
+   - /setup/configure_swtpm_device
+   # change IMA policy to simple and run one attestation scenario
+   # this is to utilize also a different parser
+   - /setup/configure_kernel_ima_module/ima_policy_simple
+   - /functional/basic-attestation-on-localhost
+   - "/container/.*"
+
+execute:
+    how: tmt


### PR DESCRIPTION
Adding new plan distribution-c9s-keylime-swtpm-dev.fmf which is disabled on main and it is there only for future rewrites of rhel-9-main