### PR TITLE
upstream: Fix tarpaulin issues with dropped -v option

### DIFF
--- a/upstream/run_rust_keylime_tests/test.sh
+++ b/upstream/run_rust_keylime_tests/test.sh
@@ -35,7 +35,7 @@ rlJournalStart
     if [ "${KEYLIME_RUST_CODE_COVERAGE}" == "1" -o "${KEYLIME_RUST_CODE_COVERAGE}" == "true" ]; then
         rlPhaseStartTest "Run cargo tests and measure code coverage"
             #run cargo tarpaulin code coverage
-            rlRun "cargo tarpaulin -v --target-dir target/tarpaulin --workspace --exclude-files 'target/*' --ignore-panics --ignore-tests --out Xml --out Html --all-features"
+            rlRun "cargo tarpaulin --verbose --target-dir target/tarpaulin --workspace --exclude-files 'target/*' --ignore-panics --ignore-tests --out Xml --out Html --all-features --engine llvm"
             rlRun "tar -czf upstream_coverage.tar.gz tarpaulin-report.html"
             rlRun "mv cobertura.xml upstream_coverage.xml"
             rlFileSubmit upstream_coverage.xml


### PR DESCRIPTION
This is a workaround for https://github.com/xd009642/tarpaulin/issues/1388

The issue was fixed upstream but not released yet, which makes our pipelines to fail.

This also adds the --engine llvm to try to solve the eventual timeout that happens on our tests.