### PR TITLE
Use keylime_create_policy instead of keylime_convert_runtime_policy

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1537,7 +1537,7 @@ limeCreateTestPolicy() {
     [ $? -ne 0 ] && return 1
 
     # create policy.json and create signed policies and keys
-    keylime_convert_runtime_policy -a allowlist.txt -e excludelist.txt -o policy.json && \
+    keylime_create_policy -a allowlist.txt -e excludelist.txt -o policy.json && \
     keylime_sign_runtime_policy -r policy.json -p dsse-ecdsa-privkey.key -b ecdsa -o policy-dsse-ecdsa.json && \
     keylime_sign_runtime_policy -r policy.json -p dsse-x509-privkey.key -b x509 -o policy-dsse-x509.json && \
     openssl ec -in dsse-ecdsa-privkey.key -pubout -out dsse-ecdsa-pubkey.pub


### PR DESCRIPTION
Given that `keylime_create_policy` script has more features and we expect users to use it it is better to do the conversion to JSON policy using `keylime_create_policy` instead of `keylime_convert_runtime_policy`.