### PR TITLE
Rust agent test fix: 

### DIFF
--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -30,7 +30,7 @@ rlJournalStart
         [ -f /etc/keylime/agent.conf ] && rlRun "mv /etc/keylime/agent.conf /etc/keylime/agent.conf.backup$$"
 
         # when TPM_BINARY_MEASUREMENTS is defined, change filepath in sources
-        SRC_FILES="src/common.rs src/main.rs keylime-agent/src/common.rs keylime-agent/src/main.rs"
+        SRC_FILES="src/common.rs src/main.rs src/config.rs keylime-agent/src/common.rs keylime-agent/src/main.rs keylime-agent/src/config.rs"
         if [ -n "${TPM_BINARY_MEASUREMENTS}" ]; then
             for FILE in ${SRC_FILES}; do
                 [ -f ${FILE} ] && rlRun "sed -i 's%/sys/kernel/security/tpm0/binary_bios_measurements%${TPM_BINARY_MEASUREMENTS}%' $FILE"


### PR DESCRIPTION
* The current test harness edits the keylime agent source code to adjust the location of the boot log.
* The location of the default value for the boot log has migrated from `common.rs` to `config.rs`
* Adding `config.rs` to the list of locations examined for replacement of boot log location.

`/sys/kernel/security/tpm0/binary_bios_measurements` -> `/var/tmp/binary_bios_measurements`

TODO: the rust agent has a testing `feature` for this; changing source code is considered unnecessary and harmful. Fix later.