### PR TITLE
registrar_ip is not needed for the verifier

### DIFF
--- a/Multihost/basic-attestation/test.sh
+++ b/Multihost/basic-attestation/test.sh
@@ -132,7 +132,6 @@ Verifier() {
 
         # Verifier configuration
         rlRun "limeUpdateConf verifier ip ${VERIFIER_IP}"
-        rlRun "limeUpdateConf verifier registrar_ip ${REGISTRAR_IP}"
         rlRun "limeUpdateConf verifier check_client_cert True"
         rlRun "limeUpdateConf verifier tls_dir ${CERTDIR}"
         rlRun "limeUpdateConf verifier trusted_server_ca '[\"cacert.pem\"]'"

--- a/container/functional/keylime_agent_container-basic-attestation/test.sh
+++ b/container/functional/keylime_agent_container-basic-attestation/test.sh
@@ -34,7 +34,6 @@ rlJournalStart
 
         #verifier
         rlRun "limeUpdateConf verifier ip $SERVER_IP"
-        rlRun "limeUpdateConf verifier registrar_ip $SERVER_IP"
 
         # start tpm emulator
         rlRun "limeStartTPMEmulator"

--- a/container/functional/keylime_all_in_container-basic-attestation/test.sh
+++ b/container/functional/keylime_all_in_container-basic-attestation/test.sh
@@ -29,7 +29,6 @@ rlJournalStart
 
         #prepare verifier container
         rlRun "limeUpdateConf verifier ip $IP_VERIFIER"
-        rlRun "limeUpdateConf verifier registrar_ip $IP_REGISTRAR"
         #for log purposes, when agent fail, we need see verifier log, that attestation failed
         rlRun "limeUpdateConf verifier log_destination stream"
 

--- a/container/functional/keylime_ipv6_multihost/test.sh
+++ b/container/functional/keylime_ipv6_multihost/test.sh
@@ -43,7 +43,6 @@ rlJournalStart
         rlRun "limeUpdateConf revocations webhook_url http://[$IP_WEBHOOK]:${HTTP_SERVER_PORT}"
 
         rlRun "limeUpdateConf verifier ip $IP_VERIFIER"
-        rlRun "limeUpdateConf verifier registrar_ip $IP_REGISTRAR"
         #for log purposes, when agent fail, we need see verifier log, that attestation failed
         rlRun "limeUpdateConf verifier log_destination stream"
 

--- a/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
+++ b/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
@@ -35,7 +35,6 @@ rlJournalStart
 
         #prepare verifier container
         rlRun "limeUpdateConf verifier ip $IP_VERIFIER"
-        rlRun "limeUpdateConf verifier registrar_ip $IP_REGISTRAR"
         #for log purposes, when agent fail, we need see verifier log, that attestation failed
         rlRun "limeUpdateConf verifier log_destination stream"
 


### PR DESCRIPTION
The verifier does not contact the registrar in any way since this commit: https://github.com/keylime/keylime/commit/bd5de712acdd77860e7dc58969181e16c7a8dc5d