### PR TITLE
Use --noautoremove when removing installed keylime

### DIFF
--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -5,7 +5,7 @@
 rlJournalStart
 
     rlPhaseStartTest "Enable repo and install rust keylime RPMs"
-        rpm -q keylime-agent-rust && rlRun "yum -y remove keylime-agent-rust"
+        rpm -q keylime-agent-rust && rlRun "yum -y remove --noautoremove keylime-agent-rust"
         # backup previous config file
         [ -f /etc/keylime/agent.conf ] && rlRun "mv /etc/keylime/agent.conf /etc/keylime/agent.conf.backup$$"
         rlRun 'cat > /etc/yum.repos.d/copr-rust-keylime-master.repo <<_EOF

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
 
     rlPhaseStartSetup "Install keylime and its dependencies"
         # remove all install keylime packages
-        rlRun "yum remove -y python3-keylime\* keylime\*"
+        rlRun "yum remove -y --noautoremove python3-keylime\* keylime\*"
         # build and install keylime-99 dummy RPM
         rlRun -s "rpmbuild -bb keylime.spec"
         RPMPKG=$( awk '/Wrote:/ { print $2 }' $rlRun_LOG )


### PR DESCRIPTION
While removing keylime yum has decided to remove some packages that were required by tests.