### PR TITLE
Modify tests to enable limited container test execution on RHEL-8

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1496,7 +1496,7 @@ This is based on an assumption that content used for testing purposes will
 be created under /keylime-tests in a directory with an unique name.
 See limeExtendNextExcludelist and limeCreateTestDir for more details.
 
-    limeCreateTestPolicy [ -e REXEXP ] [FILE] ...
+    limeCreateTestPolicy [ --lists-only ] [ -e REXEXP ] [FILE] ...
 
 =over
 
@@ -1514,6 +1514,12 @@ limeCreateTestPolicy() {
 
     local ALLOW=""
     local EXCLUDE=""
+    local LISTS_ONLY=false
+
+    if [ "$1" == "--lists-only" ]; then
+        LISTS_ONLY=true
+        shift
+    fi
 
     while [ $# -gt 0 ]; do
         if [ "$1" == "-e" ]; then
@@ -1535,6 +1541,8 @@ limeCreateTestPolicy() {
     echo -e "${EXCLUDE}" >> excludelist.txt
 
     [ $? -ne 0 ] && return 1
+
+    $LISTS_ONLY && return
 
     # create policy.json and create signed policies and keys
     keylime_create_policy -a allowlist.txt -e excludelist.txt -o policy.json && \

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1029,14 +1029,14 @@ limeWaitForKeylimeService() {
     local IP=$3
 
     if [ -z "${IP}" ]; then
-        if ! rlWaitForSocket $PORT -d 0.5 -t ${limeTIMEOUT}; then
+        if ! rlWaitForSocket $PORT -d 1 -t ${limeTIMEOUT}; then
             cat $LOGFILE
             return 1
         else
             return 0
         fi
     else
-        rlWaitForCmd "limeCheckRemotePort ${PORT} ${IP}" -m 5 -t ${limeTIMEOUT} -d 1
+        rlWaitForCmd "limeCheckRemotePort ${PORT} ${IP}" -m ${limeTIMEOUT} -t ${limeTIMEOUT} -d 1
     fi
 }
 
@@ -1170,9 +1170,9 @@ limeWaitForTPMEmulator() {
 
     # check /dev/tpm* presence if swtpm is configured as a device
     if grep -q device $__INTERNAL_limeTmpDir/swtpm_setup &> /dev/null; then
-        rlWaitForFile /dev/tpm${limeTPMDevNo} -d 0.5 -t ${limeTIMEOUT}
+        rlWaitForFile /dev/tpm${limeTPMDevNo} -d 1 -t ${limeTIMEOUT}
     else
-        rlWaitForSocket $PORT -d 0.5 -t ${limeTIMEOUT}
+        rlWaitForSocket $PORT -d 1 -t ${limeTIMEOUT}
     fi
 
 }

--- a/container/functional/keylime_all_in_container-basic-attestation/test.sh
+++ b/container/functional/keylime_all_in_container-basic-attestation/test.sh
@@ -16,7 +16,6 @@ rlJournalStart
 
     rlPhaseStartSetup "Do the keylime setup"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
-        rlAssertRpm keylime
         # update /etc/keylime.conf
         limeBackupConfig
         CONT_NETWORK_NAME="container_network"
@@ -106,8 +105,9 @@ rlJournalStart
         TESTDIR=$(limeCreateTestDir)
         rlRun "echo -e '#!/bin/bash\necho This is good-script1' > $TESTDIR/good-script1.sh && chmod a+x $TESTDIR/good-script1.sh"
         rlRun "echo -e '#!/bin/bash\necho This is good-script2' > $TESTDIR/good-script2.sh && chmod a+x $TESTDIR/good-script2.sh"
-        # create allowlist and excludelist
-        rlRun "limeCreateTestPolicy ${TESTDIR}/*"
+        # create allowlist and excludelist and generate policy.json using tenant container
+        rlRun "limeCreateTestPolicy --lists-only ${TESTDIR}/*"
+        rlRun "podman run --rm --attach stdout -v $PWD:/root:z tenant_image /bin/bash -c 'cd /root && keylime_create_policy -a allowlist.txt -e excludelist.txt 2> /dev/null' > policy.json"
 
         rlRun "limeconRunAgent $CONT_AGENT $TAG_AGENT $IP_AGENT $CONT_NETWORK_NAME $TESTDIR keylime_agent $PWD/confdir_$CONT_AGENT $(realpath ./cv_ca)"
         rlRun -s "limeWaitForAgentRegistration $AGENT_ID"
@@ -155,4 +155,3 @@ rlJournalStart
     rlPhaseEnd
 
 rlJournalEnd
-

--- a/setup/configure_kernel_ima_module/main.fmf
+++ b/setup/configure_kernel_ima_module/main.fmf
@@ -13,7 +13,3 @@ require:
 - openssl
 duration: 15m
 enabled: true
-adjust:
-  - when: distro == rhel-8 or distro = centos-stream-8
-    enabled: false
-    because: RHEL-8 has old kernel

--- a/setup/install_etc_keylime_conf/main.fmf
+++ b/setup/install_etc_keylime_conf/main.fmf
@@ -1,0 +1,12 @@
+summary: Install keylime configuration files
+description: Copies /etc/keylime from the keylime-base RPM package
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+recommend:
+test: ./test.sh
+tag:
+  - setup
+framework: beakerlib
+duration: 3m
+enabled: true

--- a/setup/install_etc_keylime_conf/test.sh
+++ b/setup/install_etc_keylime_conf/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+SUBPACKAGES="base verifier registrar tenant agent-rust"
+URL="https://odcs.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/Packages/"
+
+function extract_rpm() {
+    local NAME="$1"
+    local URL="$2"
+    rlRun "curl -o $NAME.rpm $URL"
+    rlRun "rpm2cpio $NAME.rpm | cpio -idmv"
+
+}
+
+rlJournalStart
+
+    rlPhaseStartTest
+        id keylime &> /dev/null || rlRun "useradd keylime"
+        rlRun "TMPDIR=\$( mktemp -d )"
+        rlRun "pushd $TMPDIR"
+        rlRun "curl -o filelist '$URL'"
+        # parse package NVR from filelist
+        for PKG in $SUBPACKAGES; do
+            SUFFIX=$( grep -Eo ">keylime-$PKG.*\.rpm" filelist | sed "s/>keylime-$PKG-//g" | head -1 )
+            extract_rpm "keylime-$PKG" "$URL/keylime-$PKG-$SUFFIX"
+        done
+        rlRun "cp -r etc/keylime /etc"
+        rlRun "chown -R keylime:keylime /etc/keylime"
+        rlRun "chmod -R a+r /etc/keylime"
+        rlRun "popd"
+        rlRun "rm -rf $TMPDIR"
+    rlPhaseEnd
+
+rlJournalEnd


### PR DESCRIPTION
The goal of these changes is making possible to run test
`/container/functional/keylime_all_in_container-basic-attestation`
on a RHEL-8 system (with no keylime installed) while all keylime components are running from a container.