### PR TITLE
sync: report only last 100 statuses over ncat

### DIFF
--- a/Library/sync/install-provider
+++ b/Library/sync/install-provider
@@ -3,6 +3,7 @@
 # get the script location
 DIR=$( dirname $0 )
 STATUS_FILE=/var/tmp/sync-status
+[ -n "${SYNC_STATUS_REPORT_SIZE}" ] || SYNC_STATUS_REPORT_SIZE=100
 
 touch $STATUS_FILE
 
@@ -21,7 +22,8 @@ which sync-save &> /dev/null || cp $DIR/sync-save /usr/local/bin && chmod a+x /u
 
 # now install unit files and (re)start services
 for SERVICE in sync-get.service sync-save.service; do
-    cp "$DIR/$SERVICE" /etc/systemd/system
+    # substitute actual SYNC_STATUS_REPORT_SIZE value in a service file
+    sed "s/SYNC_STATUS_REPORT_SIZE/${SYNC_STATUS_REPORT_SIZE}/g" "$DIR/$SERVICE" > /etc/systemd/system/$SERVICE
     systemctl daemon-reload
     systemctl stop $SERVICE &> /dev/null
     systemctl --now enable $SERVICE &> /dev/null

--- a/Library/sync/lib.sh
+++ b/Library/sync/lib.sh
@@ -52,6 +52,8 @@ the library load.
 
 # we are using hardcoded paths so they are preserved due to reboots
 export __INTERNAL_syncStatusFile=/var/tmp/sync-status
+# limit the reported sync status to 100 lines by default
+[ -n "${SYNC_STATUS_REPORT_SIZE}" ] || SYNC_STATUS_REPORT_SIZE=100
 
 # for backvards compatibility define SERVERS and CLIENTS variables using tmt topology
 if [ -n "${TMT_TOPOLOGY_BASH}" -a -f ${TMT_TOPOLOGY_BASH} ]; then
@@ -104,7 +106,7 @@ which sync-block &> /dev/null || cp $syncLibraryDir/sync-block /usr/local/bin &&
 
 # install and enable and start sync-get service
 if ! systemctl is-active sync-get; then
-    cp $syncLibraryDir/sync-get.service /etc/systemd/system/
+    sed "s/SYNC_STATUS_REPORT_SIZE/${SYNC_STATUS_REPORT_SIZE}/g" "$syncLibraryDir/sync-get.service" > /etc/systemd/system/sync-get.service
     systemctl daemon-reload
     systemctl --now enable sync-get &> /dev/null
     sleep 1

--- a/Library/sync/sync-get.service
+++ b/Library/sync/sync-get.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/ncat -l -k -e '/usr/bin/cat /var/tmp/sync-status' --send-only 2134
+ExecStart=/usr/bin/ncat -l -k -e '/usr/bin/tail -n SYNC_STATUS_REPORT_SIZE /var/tmp/sync-status' --send-only 2134
 TimeoutStopSec=5
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
Limit the size of a status reported over a network to last 100 statuses.