### PR TITLE
upstream/run_rust_keylime_tests: Use a single thread

### DIFF
--- a/upstream/run_rust_keylime_tests/test.sh
+++ b/upstream/run_rust_keylime_tests/test.sh
@@ -35,7 +35,7 @@ rlJournalStart
     if [ "${KEYLIME_RUST_CODE_COVERAGE}" == "1" -o "${KEYLIME_RUST_CODE_COVERAGE}" == "true" ]; then
         rlPhaseStartTest "Run cargo tests and measure code coverage"
             #run cargo tarpaulin code coverage
-            rlRun "cargo tarpaulin --verbose --target-dir target/tarpaulin --workspace --exclude-files 'target/*' --ignore-panics --ignore-tests --out Xml --out Html --all-features"
+            rlRun "cargo tarpaulin --verbose --target-dir target/tarpaulin --workspace --exclude-files 'target/*' --ignore-panics --ignore-tests --out Xml --out Html --all-features -- --test-threads=1"
             rlRun "tar -czf upstream_coverage.tar.gz tarpaulin-report.html"
             rlRun "mv cobertura.xml upstream_coverage.xml"
             rlFileSubmit upstream_coverage.xml


### PR DESCRIPTION
Avoid a deadlock by using a single thread during code test coverage measurement.

EDIT: AFAIK, this deadlock can happen only when running multiple threads under `tarpaulin` and an external process is started with `Command::run()`.