### PR TITLE
Remove keylime_tenant -f parameter from a few tests

### DIFF
--- a/functional/keylime_tenant-commands-on-localhost/test.sh
+++ b/functional/keylime_tenant-commands-on-localhost/test.sh
@@ -37,7 +37,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "-c add"
-        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --runtime-policy policy.json -f /etc/hostname -c add"
+        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --runtime-policy policy.json -c add"
         rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
     rlPhaseEnd
 

--- a/functional/keylime_tenant-ima-signature-sanity/test.sh
+++ b/functional/keylime_tenant-ima-signature-sanity/test.sh
@@ -70,26 +70,26 @@ EOF"
 
     rlPhaseStartTest "Verify IMA key using a locally stored GPG signature"
         rlRun "gpg --verify signature-gpg-genuine.sig ${limeIMAPublicKey}"
-        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json -f /etc/hostname --sign_verification_key ${limeIMAPublicKey} --signature-verification-key-sig signature-gpg-genuine.sig --signature-verification-key-sig-key gpg-key.pub -c add"
+        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json --sign_verification_key ${limeIMAPublicKey} --signature-verification-key-sig signature-gpg-genuine.sig --signature-verification-key-sig-key gpg-key.pub -c add"
         rlRun "limeWaitForAgentStatus ${AGENT_ID} 'Get Quote'"
         rlRun -s "keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'${AGENT_ID}'" $rlRun_LOG -E
     rlPhaseEnd
 
     rlPhaseStartTest "Test that IMA key verification using GPG signature fails for an invalid signature of key"
-        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json -f /etc/hostname --sign_verification_key ${limeIMAPublicKey} --signature-verification-key-sig signature-gpg-fake.sig --signature-verification-key-sig-key gpg-key.pub -c update" 1
+        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json --sign_verification_key ${limeIMAPublicKey} --signature-verification-key-sig signature-gpg-fake.sig --signature-verification-key-sig-key gpg-key.pub -c update" 1
         rlAssertGrep "WARNING - Unable to verify signature" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Verify IMA key using a downloaded GPG signature and key"
-        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json -f /etc/hostname --signature-verification-key-url 'http://localhost:8000/x509_evm.pem' --signature-verification-key-sig-url 'http://localhost:8000/signature-gpg-genuine.sig' --signature-verification-key-sig-url-key gpg-key.pub -c update"
+        rlRun "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json --signature-verification-key-url 'http://localhost:8000/x509_evm.pem' --signature-verification-key-sig-url 'http://localhost:8000/signature-gpg-genuine.sig' --signature-verification-key-sig-url-key gpg-key.pub -c update"
         rlRun "limeWaitForAgentStatus ${AGENT_ID} 'Get Quote'"
         rlRun -s "keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'${AGENT_ID}'" $rlRun_LOG -E
     rlPhaseEnd
 
     rlPhaseStartTest "Test that IMA key verification using downloaded GPG signature fails for an invalid signature of key"
-        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json -f /etc/hostname --signature-verification-key-url 'http://localhost:8000/x509_evm.pem' --signature-verification-key-sig-url 'http://localhost:8000/signature-gpg-fake.sig' --signature-verification-key-sig-url-key gpg-key.pub -c update" 1
+        rlRun -s "keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u ${AGENT_ID} --runtime-policy policy.json --signature-verification-key-url 'http://localhost:8000/x509_evm.pem' --signature-verification-key-sig-url 'http://localhost:8000/signature-gpg-fake.sig' --signature-verification-key-sig-url-key gpg-key.pub -c update" 1
         rlAssertGrep "WARNING - Unable to verify signature" $rlRun_LOG
     rlPhaseEnd
 

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -5,8 +5,8 @@ context:
 
 # modify defaults below to point upstream keylime URL to a different repo and branch
 environment:
-  KEYLIME_UPSTREAM_URL: "https://github.com/keylime/keylime.git"
-  KEYLIME_UPSTREAM_BRANCH: "master"
+  KEYLIME_UPSTREAM_URL: "https://github.com/THS-on/keylime.git"
+  KEYLIME_UPSTREAM_BRANCH: "feature/optional-payload"
   # variables below impact only plans that use /setup/install_upstream_rust_keylime
   # task, not plans using /setup/install_rust_keylime_from_copr
   RUST_KEYLIME_UPSTREAM_URL: "https://github.com/keylime/rust-keylime.git"


### PR DESCRIPTION
Because of
https://github.com/keylime/keylime/pull/1531
the usage of -f parameter is optional now.
By removing it from a few tests we exercise both variants.