### PR TITLE
Replace sdubby with grubby, bz#2269992

### DIFF
--- a/functional/install-rpm-with-ima-signature/main.fmf
+++ b/functional/install-rpm-with-ima-signature/main.fmf
@@ -20,7 +20,6 @@ require:
   - rpm-build
   - rpm-sign
   - gawk
-  - expect
   - gnupg2
   - rng-tools
 # do not install rpm-plugin-ima so we won't install RHEL packages with signatures

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -19,6 +19,8 @@ prepare:
      - systemctl disable --now dnf-makecache.timer || true
      - dnf makecache
      - dnf update -y tpm2-tss tpm2-tools
+     # replace sdubby with grubby, bz#2269992
+     - rpm -q sdubby && dnf swap -y sdubby grubby || true
 
 adjust:
   - when: distro == centos-stream-8


### PR DESCRIPTION
- workaround bz#2269992 by switching sdubby package with grubby
- fix test failure on Rawhide in  /functional/install-rpm-with-ima-signature by avoiding expect usage in rpm --addsign