### PR TITLE
Provide public key for signature verification on command line

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1585,8 +1585,8 @@ limeCreateTestPolicy() {
     keylime_create_policy -a allowlist.txt -e excludelist.txt -o policy.json && \
     keylime_sign_runtime_policy -r policy.json -p dsse-ecdsa-privkey.key -b ecdsa -o policy-dsse-ecdsa.json && \
     keylime_sign_runtime_policy -r policy.json -p dsse-x509-privkey.key -b x509 -o policy-dsse-x509.json && \
-    openssl ec -in dsse-ecdsa-privkey.key -pubout -out dsse-ecdsa-pubkey.pub
-
+    openssl ec -in dsse-ecdsa-privkey.key -pubout -out dsse-ecdsa-pubkey.pub && \
+    openssl ec -in dsse-x509-privkey.key -pubout -out dsse-x509-pubkey.pub
 }
 
 true <<'=cut'

--- a/functional/tenant-runtime-policy-sanity/test.sh
+++ b/functional/tenant-runtime-policy-sanity/test.sh
@@ -73,7 +73,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Test addruntimepolicy providing --runtime-policy-url with x509-signed DSSE policy"
-        rlRun -s "keylime_tenant -c addruntimepolicy --runtime-policy-name list7 --runtime-policy-url 'http://localhost:8000/policy-dsse-x509.json' --runtime-policy-checksum ${CHECKSUM_DSSE_X509}"
+        rlRun -s "keylime_tenant -c addruntimepolicy --runtime-policy-name list7 --runtime-policy-sig-key dsse-x509-pubkey.pub --runtime-policy-url 'http://localhost:8000/policy-dsse-x509.json' --runtime-policy-checksum ${CHECKSUM_DSSE_X509}"
         rlAssertGrep "{'code': 201, 'status': 'Created', 'results': {}}" $rlRun_LOG
     rlPhaseEnd
 
@@ -152,7 +152,7 @@ rlJournalStart
 
     rlPhaseStartTest "Test addruntimepolicy not matching DSSE policy with embedded x509 cert"
         rlRun "sed 's/0/1/' policy-dsse-x509.json > policy-dsse-x509-bad.json"
-        rlRun -s "keylime_tenant -c addruntimepolicy --runtime-policy-name list23 --runtime-policy policy-dsse-x509-bad.json" 1
+        rlRun -s "keylime_tenant -c addruntimepolicy --runtime-policy-name list23 --runtime-policy policy-dsse-x509-bad.json --runtime-policy-sig-key dsse-x509-pubkey.pub" 1
         rlAssertGrep "failed DSSE signature verification" $rlRun_LOG
     rlPhaseEnd
 


### PR DESCRIPTION
Keylime does not allow the trivial passing of signature verification on the self-signed certificate embedded in the DSSE envelope of a signed policy anymore. Instead, it requires that a public key for signature verification be given by the user. Therefore, pass the public key needed for signature verification via the command line.

This PR requires agreement on https://github.com/keylime/keylime/pull/1482