### PR TITLE
Stop building tpm2-openssl provider

### DIFF
--- a/functional/iak-idevid-register-with-certificates/main.fmf
+++ b/functional/iak-idevid-register-with-certificates/main.fmf
@@ -14,6 +14,7 @@ require:
   - xxd
 recommend:
   - keylime
+  - tpm2-openssl
 duration: 5m
 enabled: true
 adjust:


### PR DESCRIPTION
Rawhide already containt pre-built openssl-provider so we should be using it.