### PR TITLE
Update regexp as comma is not always present

### DIFF
--- a/setup/generate_coverage_report/patchcov.py
+++ b/setup/generate_coverage_report/patchcov.py
@@ -130,7 +130,7 @@ def get_patch_coverage(patch_path, db_path):
 
             if line.startswith('@@ '):
                 # indicator of patch start
-                line_no = int(re.sub(r'.*\+([0-9]+),.*', r'\1', line)) - 1
+                line_no = int(re.sub(r'.*\+([0-9]+).*', r'\1', line)) - 1
                 print_line(line)
                 code_change = True
 


### PR DESCRIPTION
Should fix the following traceback:

Traceback (most recent call last):
  File "/var/ARTIFACTS/work-e2e-with-revocationmuq079lo/packit-ci/e2e-with-revocation/discover/default-0/tests/setup/generate_coverage_report/./patchcov.py", line 197, in <module>
    v = get_patch_coverage(patch_path, db_path)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/ARTIFACTS/work-e2e-with-revocationmuq079lo/packit-ci/e2e-with-revocation/discover/default-0/tests/setup/generate_coverage_report/./patchcov.py", line 133, in get_patch_coverage
    line_no = int(re.sub(r'.*\+([0-9]+),.*', r'\1', line)) - 1
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '@@ -0,0 +1 @@'