### PR TITLE
Do not disable distribution-c9s-keylime-multihost

### DIFF
--- a/plans/distribution-c9s-keylime-multihost.fmf
+++ b/plans/distribution-c9s-keylime-multihost.fmf
@@ -38,9 +38,6 @@ adjust+:
     enabled: false
     because: we want to run this plan only in the multihost pipeline
 
-  - when: distro != centos-stream-9
-    enabled: false
-
   - when: distro == centos-stream-9
     prepare+:
       - how: shell


### PR DESCRIPTION
It is handy not to disable the plan on distro!=c9s so that we can schedule it eventually on a different distro.