### PR TITLE
Use the latest old supported version that is not the current version to test API bump

### DIFF
--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -43,9 +43,6 @@ rlJournalStart
         # start keylime_verifier
         rlRun "limeStartVerifier"
         rlRun "limeWaitForVerifier"
-
-        OLD_VERSION="$(grep "Supported older API versions: " "$(limeVerifierLogfile)" | grep -o -E '[0-9]+\.[0-9]+' | tail -1)"
-
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
         # create allowlist and excludelist
@@ -59,6 +56,12 @@ rlJournalStart
         rlRun "rlFileBackup --namespace agent /usr/bin/keylime_agent"
         rlRun "git clone ${RUST_KEYLIME_UPSTREAM_URL} ${WORKDIR}/rust-keylime"
         rlRun "pushd ${WORKDIR}/rust-keylime"
+
+        # Get a supported version older than the current
+        CURRENT_VERSION="$(grep -E '(^.*API_VERSION.*v)([0-9]+\.[0-9]+)' keylime-agent/src/common.rs | grep -o -E '[0-9]+\.[0-9]+')"
+        OLD_VERSION="$(grep -o -E "Supported older API versions: .*" "$(limeVerifierLogfile)" | grep -o -E '[0-9]+\.[0-9]+' | sed -n "1,/^$CURRENT_VERSION\$/ p" | grep -v "^$CURRENT_VERSION\$" | tail -1)"
+
+        # Replace the API version to fake an older version
         rlRun "sed -i -E \"s/(^.*API_VERSION.*v)([0-9]+\.[0-9]+)/\1$OLD_VERSION/\" keylime-agent/src/common.rs"
         rlRun "git diff"
         # Replace agent binary


### PR DESCRIPTION
This change is to cover a corner case when the python components API version is bumped before the agent API version is bumped.

In such a case, the latest old supported API version for the verifier would be the current agent API version. Then it is necessary to use the second to last to cause a difference in the API version.