### PR TITLE
install_upstream_rust_keylime: Do not pin the rustc version

### DIFF
--- a/setup/install_upstream_rust_keylime/main.fmf
+++ b/setup/install_upstream_rust_keylime/main.fmf
@@ -8,14 +8,15 @@ tag:
  - setup
 framework: beakerlib
 require:
- - git
- - yum
- - openssl-devel
- - gcc
- - tpm2-tss-devel
- - libarchive-devel
+ - cargo
  - clang-devel
+ - gcc
+ - git
+ - libarchive-devel
+ - openssl-devel
  - rpm-build
+ - tpm2-tss-devel
+ - yum
 duration: 20m
 enabled: true
 extra-nitrate: TC#0613570

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -35,17 +35,13 @@ rlJournalStart
             CARGO_FLAGS="--features=testing"
         fi
 
-        rlRun "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y"
-        rlRun "source /root/.cargo/env"
-        # This pinned version allows generated instrumented code for tarpaulin
-        # to generate code coverage measurements
-        rlRun "rustup default 1.74.1"
-        rlRun "rustup component add llvm-tools-preview"
-        sleep 3
-        #install parser for code coverage files
-        rlRun "cargo install grcov"
-        # -Z is deprecated, use -C
         if [ "${KEYLIME_RUST_CODE_COVERAGE}" == "1" -o "${KEYLIME_RUST_CODE_COVERAGE}" == "true" ]; then
+            rlRun "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y"
+            rlRun "source /root/.cargo/env"
+            rlRun "rustup component add llvm-tools-preview"
+            #install parser for code coverage files
+            rlRun "cargo install grcov"
+            # -Z is deprecated, use -C
             RUSTFLAGS='-Cinstrument-coverage'
         fi
 


### PR DESCRIPTION
The current stable rust compiler (1.78.0) has the features necessary to instrument the code for coverage measurement by cargo-tarpaulin.

This change removes the pinning of the version, using the current stable rust compiler instead.

This also installs the coverage generation tools only when code coverage is requested.

Fix #584