### PR TITLE
Add Obsoletes to keylime-99 SPEC

### DIFF
--- a/setup/install_upstream_keylime/keylime.spec
+++ b/setup/install_upstream_keylime/keylime.spec
@@ -4,12 +4,12 @@ Release:	1
 Summary:	Dummy package preventing keylime RPM installation
 License:	GPLv2+	
 BuildArch:  noarch
-Provides: keylime-base
-Provides: keylime-verifier
-Provides: keylime-registrar
-Provides: keylime-tenant
-Provides: python3-keylime
-Provides: python3-keylime-agent
+Provides: keylime-base = 99
+Provides: keylime-verifier = 99
+Provides: keylime-registrar = 99
+Provides: keylime-tenant = 99
+Provides: python3-keylime = 99
+Obsoletes: keylime-base < 99
 
 %description
 Dummy package that prevents replacing installed keylime bits with keylime RPM


### PR DESCRIPTION
A change in DNF5 could be a root cause for current test failures on Rawhide.
DNF5 is pulling the real `keylime-base` as a require of `keylime-agent-rust`, because our `keylime-99` does not provide `user(keylime)` and `group(keylime)`.
The following can be seen in the test log:
```
keylime-99-1.noarch
keylime-base-7.10.0-1.fc41.x86_64
```
With this update we are adding Obsoletes definitions to keylime SPEC so that subpackages won't be pulled in.