### PR TITLE
Stop IDevID test being dependant on a previous test running

### DIFF
--- a/functional/iak-idevid-register-with-certificates/test.sh
+++ b/functional/iak-idevid-register-with-certificates/test.sh
@@ -137,6 +137,7 @@ rlJournalStart
 
     rlPhaseStartTest "Successful registration - IDevID and IAK certs verified, and IAK verifies AK"
         # Add CA to store
+        rlRun "mkdir -p $TPM_CERTS"
         rlRun "cp ./ca/certs/klca-chain.cert.pem $TPM_CERTS/"
         rlRun "limeStartAgent"
         # Agent can now register with IDevID and IAK getting verified


### PR DESCRIPTION
At the moment, the IDevID test (```iak-idevid-register-with-certificates```) works because the test ```ek-cert-use-ek_handle-custom-ca_certs``` previously ran and created the tpm certs folder.

This change makes sure the folder has been created, allowing the test to be run independently of other tests running.