### PR TITLE
Move to c10s based dockerfiles

### DIFF
--- a/Library/test-helpers/Dockerfile.agent
+++ b/Library/test-helpers/Dockerfile.agent
@@ -1,7 +1,7 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10-development
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
-  curl -o /etc/yum.repos.d/c9s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo' && \
+  curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \
   cat /etc/yum.repos.d/* && \
   dnf install -y keylime-agent-rust util-linux-core which && \
   dnf clean all

--- a/Library/test-helpers/Dockerfile.registrar
+++ b/Library/test-helpers/Dockerfile.registrar
@@ -1,7 +1,7 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10-development
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
-  curl -o /etc/yum.repos.d/c9s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo' && \
+  curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \
   cat /etc/yum.repos.d/* && \
   dnf install -y keylime-registrar which && \
   dnf clean all

--- a/Library/test-helpers/Dockerfile.tenant
+++ b/Library/test-helpers/Dockerfile.tenant
@@ -1,7 +1,7 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10-development
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
-  curl -o /etc/yum.repos.d/c9s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo' && \
+  curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \
   cat /etc/yum.repos.d/* && \
   dnf install -y keylime-tenant which && \
   dnf clean all

--- a/Library/test-helpers/Dockerfile.upstream.c10s
+++ b/Library/test-helpers/Dockerfile.upstream.c10s
@@ -1,0 +1,10 @@
+FROM quay.io/centos/centos:stream10-development
+COPY lime_con_install_upstream.sh /usr/local/bin/lime_con_install_upstream
+RUN \
+    rm -f /etc/yum.repos.d/centos.repo && \
+    curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \
+    cat /etc/yum.repos.d/* && \
+    chmod a+x /usr/local/bin/lime_con_* && \
+    mkdir -p /mnt/keylime_sources && \
+    cp -r /mnt/keylime_sources /var/tmp/keylime_sources && \
+    /usr/local/bin/lime_con_install_upstream

--- a/Library/test-helpers/Dockerfile.verifier
+++ b/Library/test-helpers/Dockerfile.verifier
@@ -1,7 +1,7 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10-development
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
-  curl -o /etc/yum.repos.d/c9s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c9s.repo' && \
+  curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \
   cat /etc/yum.repos.d/* && \
   dnf install -y keylime-verifier which && \
   dnf clean all

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -2164,7 +2164,7 @@ limeconPrepareImage() {
 
     # copy lime_con_install_upstream.sh to the current dir just in case it would be needed
     if grep -q 'lime_con_install_upstream.sh' ${DOCKER_FILE}; then
-        cp ${limeLibraryDir}/lime_con_install_upstream.sh .
+        cp -n ${limeLibraryDir}/lime_con_install_upstream.sh .
     fi
 
     CMDLINE="podman build $ARGS -t=$TAG --file=$DOCKER_FILE ."

--- a/Library/test-helpers/lime_con_install_upstream.sh
+++ b/Library/test-helpers/lime_con_install_upstream.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # enable epel repo
-yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+#yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 # install build requires for C9S
 yum -y install \
@@ -11,7 +11,7 @@ yum -y install \
     openssh-server \
     python3-alembic \
     python3-cryptography \
-    python3-gnupg \
+    python-gpg \
     python3-jinja2 \
     python3-jsonschema \
     python3-lark-parser \
@@ -22,10 +22,10 @@ yum -y install \
     python3-pyasn1-modules \
     python3-pyyaml \
     python3-requests \
+    python3-setuptools \
     python3-sqlalchemy \
     python3-tornado \
     python3-typing-extensions \
-    python3-zmq \
     tpm2-tools \
     which
 

--- a/container/functional/keylime_agent_container-basic-attestation/test.sh
+++ b/container/functional/keylime_agent_container-basic-attestation/test.sh
@@ -10,7 +10,7 @@
 # registry set in REGISTRY (default quay.io). Otherwise, the test builds the
 # agent image from the Dockerfile set in AGENT_DOCKERFILE.
 
-[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c9s
+[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c10s
 
 [ -n "$REGISTRY" ] || REGISTRY=quay.io
 

--- a/container/functional/keylime_all_in_container-basic-attestation/test.sh
+++ b/container/functional/keylime_all_in_container-basic-attestation/test.sh
@@ -5,10 +5,10 @@
 #Machine should have /dev/tpm0 or /dev/tpmrm0 device
 AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
-[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$TENANT_DOCKERFILE" ] || TENANT_DOCKERFILE=Dockerfile.upstream.c9s
+[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$TENANT_DOCKERFILE" ] || TENANT_DOCKERFILE=Dockerfile.upstream.c10s
 
 [ -n "$REGISTRY" ] || REGISTRY=quay.io
 

--- a/container/functional/keylime_ipv6_multihost/test.sh
+++ b/container/functional/keylime_ipv6_multihost/test.sh
@@ -14,9 +14,9 @@ HTTP_SERVER_PORT=8080
 # The same applies for REGISTRAR_IMAGE/REGISTRAR_DOCKERFILE and
 # AGENT_IMAGE/AGENT_DOCKERFILE.
 
-[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c9s
+[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c10s
 [ -n "$WEBHOOK_DOCKERFILE" ] || WEBHOOK_DOCKERFILE=Dockerfile.webhook
 
 [ -n "$REGISTRY" ] || REGISTRY=quay.io

--- a/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
+++ b/container/functional/keylime_verifier_registrar_container-basic-attestation/test.sh
@@ -13,9 +13,9 @@ AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 #
 # The same applies for REGISTRAR_IMAGE and respective REGISTRAR_DOCKERFILE.
 
-[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c9s
-[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c9s
+[ -n "$VERIFIER_DOCKERFILE" ] || VERIFIER_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$REGISTRAR_DOCKERFILE" ] || REGISTRAR_DOCKERFILE=Dockerfile.upstream.c10s
+[ -n "$AGENT_DOCKERFILE" ] || AGENT_DOCKERFILE=Dockerfile.upstream.c10s
 
 [ -n "$REGISTRY" ] || REGISTRY=quay.io
 

--- a/plans/distribution-c9s-keylime-swtpm-dev.fmf
+++ b/plans/distribution-c9s-keylime-swtpm-dev.fmf
@@ -20,6 +20,7 @@ environment:
 discover:
   how: fmf
   test: 
+   - /setup/apply_workarounds
    # need two TPM devices
    - /setup/configure_swtpm_device
    - /setup/configure_swtpm_device

--- a/plans/distribution-c9s-keylime-tests-github-ci.fmf
+++ b/plans/distribution-c9s-keylime-tests-github-ci.fmf
@@ -21,6 +21,7 @@ prepare+:
 discover:
   how: fmf
   test: 
+   - /setup/apply_workarounds
    - /setup/configure_tpm_emulator
    # change IMA policy to simple and run one attestation scenario
    # this is to utilize also a different parser

--- a/plans/upstream-keylime-containers.fmf
+++ b/plans/upstream-keylime-containers.fmf
@@ -31,5 +31,5 @@ adjust+:
     enabled: false
     because: we want to run this plan only for PRs targeting the main branch
 
-  - when: distro != fedora-39 and distro != centos-stream-9
+  - when: distro != fedora-39 and distro != centos-stream-10
     enabled: false

--- a/plans/upstream-keylime-swtpm-dev.fmf
+++ b/plans/upstream-keylime-swtpm-dev.fmf
@@ -4,9 +4,9 @@ summary:
 environment+:
   TPM_BINARY_MEASUREMENTS: /var/tmp/binary_bios_measurements
   KEYLIME_RUST_CODE_COVERAGE: 1
-  AGENT_DOCKERFILE: Dockerfile.upstream.c9s
-  VERIFIER_DOCKERFILE: Dockerfile.upstream.c9s
-  REGISTRAR_DOCKERFILE: Dockerfile.upstream.c9s
+  AGENT_DOCKERFILE: Dockerfile.upstream.c10s
+  VERIFIER_DOCKERFILE: Dockerfile.upstream.c10s
+  REGISTRAR_DOCKERFILE: Dockerfile.upstream.c10s
 
 discover:
   how: fmf
@@ -32,7 +32,7 @@ adjust+:
     enabled: false
     because: we want to run this plan only for PRs targeting the main branch
 
-  - when: distro != fedora-39 and distro != centos-stream-9
+  - when: distro != fedora-39 and distro != centos-stream-10
     enabled: false
 
   - when: distro == centos-stream-9

--- a/setup/apply_workarounds/keylime_tests_workarounds.te.el10
+++ b/setup/apply_workarounds/keylime_tests_workarounds.te.el10
@@ -7,6 +7,7 @@ require {
 	type systemd_sysv_generator_t;
 	type systemd_fstab_generator_t;
 	type nfsd_t;
+        type vsock_device_t;
 	class bpf { map_read map_write };
 }
 
@@ -17,3 +18,5 @@ allow systemd_gpt_generator_t init_t:bpf { map_read map_write };
 allow systemd_rc_local_generator_t init_t:bpf { map_read map_write };
 allow systemd_sysv_generator_t init_t:bpf { map_read map_write };
 
+# dontaudit messages from RHEL-47288
+dontaudit init_t vsock_device_t:chr_file { read };


### PR DESCRIPTION
Since we are no longer able to install upstream keylime to c9s we should also base our container tests and dockerfiles on c10s.