### PR TITLE
Install swtpm in the test

### DIFF
--- a/setup/configure_swtpm_device/main.fmf
+++ b/setup/configure_swtpm_device/main.fmf
@@ -9,10 +9,11 @@ tag:
 framework: beakerlib
 require:
 - yum
-- swtpm
-- swtpm-tools
 - tpm2-tss
 - tpm2-tools
 - selinux-policy-devel
+recommend:
+- swtpm
+- swtpm-tools
 duration: 5m
 enabled: true

--- a/setup/configure_swtpm_device/test.sh
+++ b/setup/configure_swtpm_device/test.sh
@@ -17,6 +17,7 @@ rlJournalStart
     rlPhaseStartSetup "Install TPM emulator"
 
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rpm -q swtpm swtpm-tools || rlRun 'dnf -y install swtpm swtpm-tools'
         rlRun "echo device > $__INTERNAL_limeTmpDir/swtpm_setup"
 
         # load the kernel module


### PR DESCRIPTION
ppc64le doesn't ship swtpm and having it in requires causes test job aborts.