### PR TITLE
Backport changes to use TLS on revocation notification webhook

### DIFF
--- a/Library/test-helpers/Dockerfile.webhook
+++ b/Library/test-helpers/Dockerfile.webhook
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 RUN microdnf makecache && \
-    microdnf install -y nmap-ncat && \
+    microdnf install -y openssl && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/*
 
@@ -9,4 +9,4 @@ ENV WEBHOOK_SERVER_PORT 8080
 
 EXPOSE $WEBHOOK_SERVER_PORT
 
-CMD ["/usr/bin/bash", "-c", "/usr/bin/ncat --no-shutdown -k -l -c '/usr/bin/sleep 3 && echo HTTP/1.1 200 OK' -o /var/tmp/webhook/revocation_log $WEBHOOK_SERVER_PORT"]
+CMD ["/usr/bin/bash", "-c", "openssl s_server -debug -cert /var/tmp/webhook/server-cert.crt -key /var/tmp/webhook/server-private.pem -CAfile /var/tmp/webhook/cacert.crt -port ${WEBHOOK_SERVER_PORT} &> /var/tmp/webhook/revocation_log"]

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -2288,9 +2288,9 @@ limeconRun() {
     local CMDLINE
 
     if [ -n "${COMMAND}" ]; then
-        CMDLINE="podman run -d --name $NAME --net $NETWORK --ip $IP --cap-add CAP_AUDIT_WRITE --cap-add CAP_SYS_CHROOT $EXTRA_PODMAN_ARGS --entrypoint $COMMAND localhost/$TAG ${COMMAND_ARGS}"
+        CMDLINE="podman run -di --name $NAME --net $NETWORK --ip $IP --cap-add CAP_AUDIT_WRITE --cap-add CAP_SYS_CHROOT $EXTRA_PODMAN_ARGS --entrypoint $COMMAND localhost/$TAG ${COMMAND_ARGS}"
     else
-        CMDLINE="podman run -d --name $NAME --net $NETWORK --ip $IP --cap-add CAP_AUDIT_WRITE --cap-add CAP_SYS_CHROOT $EXTRA_PODMAN_ARGS localhost/$TAG"
+        CMDLINE="podman run -di --name $NAME --net $NETWORK --ip $IP --cap-add CAP_AUDIT_WRITE --cap-add CAP_SYS_CHROOT $EXTRA_PODMAN_ARGS localhost/$TAG"
     fi
 
     echo -e "\nRunning podman:\n$CMDLINE"


### PR DESCRIPTION
Backport the changes from `main` to use TLS on revocation notification webhook.

This is necessary to make tests on https://gitlab.com/redhat/centos-stream/rpms/keylime/-/merge_requests/37 to pass.