### PR TITLE
keylime_policy-commands: Do not expect algorithm in policy

### DIFF
--- a/functional/keylime_policy-commands/test.sh
+++ b/functional/keylime_policy-commands/test.sh
@@ -143,7 +143,6 @@ rlJournalStart
             rlRun "${algo}sum rootfs/test | awk '{print \$1}' > test.${algo}"
             rlRun "${algo}sum rootfs/nested/nested | awk '{print \$1}' > nested.${algo}"
             rlRun -s "keylime_policy create runtime --rootfs rootfs --algo ${algo}"
-            rlAssertGrep "${algo}" "$rlRun_LOG"
             rlAssertGrep "$(cat test.${algo})" "$rlRun_LOG"
             rlAssertGrep "$(cat nested.${algo})" "$rlRun_LOG"
         done


### PR DESCRIPTION
Previously, the keylime_policy command would set the IMA template hash algorithm to follow the algorithm set through --algo option.

This was an incorrect behavior and was recently fixed. Now the IMA template hash algorithm is hardcoded as SHA-1, following kernel implementation.