### PR TITLE
setup/configure_kernel_ima_module: Add missing dependency

### DIFF
--- a/setup/configure_kernel_ima_module/main.fmf
+++ b/setup/configure_kernel_ima_module/main.fmf
@@ -12,6 +12,7 @@ require:
 - tpm2-tools
 - openssl
 - attr
+- ima-evm-utils
 recommend:
 - mokutil
 duration: 15m


### PR DESCRIPTION
The test requires `ima-evm-utils`, but it was missing in the main.fmf