### PR TITLE
Add CI parity test

### DIFF
--- a/.github/workflows/test_parity.yml
+++ b/.github/workflows/test_parity.yml
@@ -1,0 +1,28 @@
+name: Check upstream CI test parity
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install tmt
+        run: |
+          sudo apt install libkrb5-dev pkg-config libvirt-dev genisoimage qemu-kvm libvirt-daemon-system
+          pip install tmt
+
+      - name: Check test parity
+        run: ./scripts/check_upstream_test_parity.sh

--- a/scripts/check_upstream_test_parity.sh
+++ b/scripts/check_upstream_test_parity.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+KEYLIME_PLAN_URL="https://raw.githubusercontent.com/keylime/keylime/refs/heads/master/packit-ci.fmf"
+AGENT_PLAN_URL="https://raw.githubusercontent.com/keylime/rust-keylime/refs/heads/master/packit-ci.fmf"
+
+function test_filter() {
+	sed 's#^[^/]*##g' | grep -E "^/(functional|compatibility|regression)" | sort -u
+}
+
+function get_upstream_tests() {
+	curl -s "$1" | test_filter
+}
+
+function get_test_list() {
+	tmt -c swtpm=yes test ls --filter 'enabled: true' 2>/dev/null | test_filter
+}
+
+function do_diff() {
+	echo "Missing tests:"
+	diff -w "$1" "$2" | grep '^<' && return 1
+}
+
+RESULT=0
+
+echo "Getting a list of available tests..."
+get_test_list > tests.txt
+echo "Getting a list of tests used in keylime CI..."
+get_upstream_tests "$KEYLIME_PLAN_URL" > keylime.txt
+echo
+do_diff tests.txt keylime.txt
+RESULT=$(( RESULT+$? ))
+echo
+echo "Getting a list of tests used in rust-keylime CI..."
+get_upstream_tests "$AGENT_PLAN_URL" > agent.txt
+echo
+do_diff tests.txt agent.txt
+RESULT=$(( RESULT+$? ))
+exit $RESULT


### PR DESCRIPTION
Adds a new check which fails when there are missing tests in keylime upstream CI plans.