### PR TITLE
Add upstream CI test filtering capabilities

### DIFF
--- a/functional/keylime-policy-commands/main.fmf
+++ b/functional/keylime-policy-commands/main.fmf
@@ -8,6 +8,7 @@ test: ./test.sh
 framework: beakerlib
 tag:
   - CI-Tier-1
+  - not-agent-upstream-CI
 require:
   - yum
   - createrepo_c

--- a/scripts/check_upstream_test_parity.sh
+++ b/scripts/check_upstream_test_parity.sh
@@ -12,27 +12,33 @@ function get_upstream_tests() {
 }
 
 function get_test_list() {
-	tmt -c swtpm=yes test ls --filter 'enabled: true' 2>/dev/null | test_filter
+	tmt -c swtpm=yes test ls --filter 'enabled: true' --filter 'tag: -not-keylime-upstream-CI' 2>/dev/null | test_filter
+}
+
+function get_agent_test_list() {
+	tmt -c swtpm=yes test ls --filter 'enabled: true' --filter 'tag: -not-agent-upstream-CI' 2>/dev/null | test_filter
 }
 
 function do_diff() {
 	echo "Missing tests:"
-	diff -w "$1" "$2" | grep '^<' && return 1
+	diff -w "$1" "$2" > diff.txt
+        ! grep '^<' diff.txt
 }
 
 RESULT=0
 
 echo "Getting a list of available tests..."
 get_test_list > tests.txt
+get_agent_test_list > agent_tests.txt
 echo "Getting a list of tests used in keylime CI..."
 get_upstream_tests "$KEYLIME_PLAN_URL" > keylime.txt
 echo
-do_diff tests.txt keylime.txt
+do_diff agent_tests.txt keylime.txt
 RESULT=$(( RESULT+$? ))
 echo
 echo "Getting a list of tests used in rust-keylime CI..."
 get_upstream_tests "$AGENT_PLAN_URL" > agent.txt
 echo
-do_diff tests.txt agent.txt
+do_diff agent_tests.txt agent.txt
 RESULT=$(( RESULT+$? ))
 exit $RESULT


### PR DESCRIPTION
Adds possibility to ignore tests tagged with `not-agent-upstream-CI` and `not-keylime-upstream-CI` in the upstream CI test parity check.