### PR TITLE
Set log level for the rust keylime lib as well

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -2423,7 +2423,7 @@ limeconRunAgent() {
         PUBLISH_PORTS="-P"
     fi
 
-    local EXTRA_ARGS="--privileged $ADD_PORT $ADD_REV_PORT $PUBLISH_PORTS --volume=/sys/kernel/security/:/sys/kernel/security/:ro --volume=$TESTDIR:$TESTDIR -e RUST_LOG=keylime_agent=trace -e TCTI=device:/dev/tpmrm${limeTPMDevNo}"
+    local EXTRA_ARGS="--privileged $ADD_PORT $ADD_REV_PORT $PUBLISH_PORTS --volume=/sys/kernel/security/:/sys/kernel/security/:ro --volume=$TESTDIR:$TESTDIR -e RUST_LOG=keylime_agent=trace,keylime=trace -e TCTI=device:/dev/tpmrm${limeTPMDevNo}"
 
     if [ -n "$CONFDIR" ]; then
         EXTRA_ARGS="--volume=${CONFDIR}:/etc/keylime/:z $EXTRA_ARGS"

--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -32,7 +32,7 @@ _EOF'
         rlRun "mkdir -p /etc/keylime/agent.conf.d"
         rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
 [Service]
-Environment=\"RUST_LOG=keylime_agent=trace\"
+Environment=\"RUST_LOG=keylime_agent=trace,keylime=trace\"
 _EOF"
         # If the TPM_BINARY_MEASUREMENTS env var is set, set the binary
         # measurements location for the service

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -67,7 +67,7 @@ _EOF'
         rlRun "mkdir -p /etc/systemd/system/keylime_agent.service.d"
         rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
 [Service]
-Environment=\"RUST_LOG=keylime_agent=trace\"
+Environment=\"RUST_LOG=keylime_agent=trace,keylime=trace\"
 _EOF"
 
         # If the TPM_BINARY_MEASUREMENTS env var is set, set the binary


### PR DESCRIPTION
Some of the log messages were moved from the `keylime_agent` to the `keylime` library.  With these changes, the messages logged by the keylime library are also visible.