### PR TITLE
basic-attestation-on-localhost-api-version-bump: Fix regex for version number

### DIFF
--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -45,7 +45,7 @@ rlJournalStart
     rlPhaseStartTest "Get agent supported versions"
         rlRun "limeStartAgent"
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
-        mapfile -t SUPPORTED_VERSIONS< <(grep -ohE '> Starting server with API version.*' "$(limeAgentLogfile)" | grep -ohE '[0-9]*\.[0-9]*' | sort -V)
+        mapfile -t SUPPORTED_VERSIONS< <(grep -ohE '> Starting server with API version.*' "$(limeAgentLogfile)" | grep -ohE '[0-9]+\.[0-9]+' | sort -V)
         if [[ "${#SUPPORTED_VERSIONS[@]}" -lt 2 ]]; then
             rlFail "Agent supports only one API version: ${SUPPORTED_VERSIONS[*]}"
         fi

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -9,8 +9,8 @@ environment:
   KEYLIME_UPSTREAM_BRANCH: "master"
   # variables below impact only plans that use /setup/install_upstream_rust_keylime
   # task, not plans using /setup/install_rust_keylime_from_copr
-  RUST_KEYLIME_UPSTREAM_URL: "https://github.com/ansasaki/rust-keylime.git"
-  RUST_KEYLIME_UPSTREAM_BRANCH: "multiple_api"
+  RUST_KEYLIME_UPSTREAM_URL: "https://github.com/keylime/rust-keylime.git"
+  RUST_KEYLIME_UPSTREAM_BRANCH: "master"
 
 prepare:
   - how: shell


### PR DESCRIPTION
Require digits on the version number by replacing `'*'` with `'+'` in the regex.

This also reverts a temporary commit which should be dropped before merging