### PR TITLE
Add another acceptable error message for CVE-2023-3674 test

### DIFF
--- a/regression/CVE-2023-3674/test.sh
+++ b/regression/CVE-2023-3674/test.sh
@@ -79,7 +79,7 @@ rlJournalStart
         rlRun "cat malformed_quote > $ATTESTATION_FILE"
         rlRun -s "keylime_attest" 1
         rlAssertGrep "ERROR - Error verifying quote" "$rlRun_LOG"
-        rlAssertGrep "raise InvalidSignature" "$rlRun_LOG"
+        rlAssertGrep "(raise InvalidSignature|cryptography.exceptions.InvalidSignature)" "$rlRun_LOG" -E
         rlAssertGrep "The following agents failed attestation" "$rlRun_LOG"
     rlPhaseEnd
 


### PR DESCRIPTION
This is a cherry-pick of 0e7afa6ab7cf1f4969f87ad50a5e76dcb75c6243

This adds an alternative acceptable error message for the raised exception.