### PR TITLE
fedora-40: Cherry pick fixes for IDevID/IAK test

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -2382,7 +2382,7 @@ limeconRunAgent() {
         PUBLISH_PORTS="-P"
     fi
 
-    local EXTRA_ARGS="--privileged $ADD_PORT $ADD_REV_PORT $PUBLISH_PORTS --volume=/sys/kernel/security/:/sys/kernel/security/:ro --volume=$TESTDIR:$TESTDIR -e RUST_LOG=keylime_agent=trace -e TCTI=device:/dev/tpmrm${limeTPMDevNo}"
+    local EXTRA_ARGS="--privileged $ADD_PORT $ADD_REV_PORT $PUBLISH_PORTS --volume=/sys/kernel/security/:/sys/kernel/security/:ro --volume=$TESTDIR:$TESTDIR -e RUST_LOG=keylime_agent=trace,keylime=trace -e TCTI=device:/dev/tpmrm${limeTPMDevNo}"
 
     if [ -n "$CONFDIR" ]; then
         EXTRA_ARGS="--volume=${CONFDIR}:/etc/keylime/:z $EXTRA_ARGS"

--- a/functional/iak-idevid-register-with-certificates/main.fmf
+++ b/functional/iak-idevid-register-with-certificates/main.fmf
@@ -11,7 +11,7 @@ framework: beakerlib
 require:
   - yum
   - tpm2-tools 
-  - xxd
+  - /usr/bin/xxd
 recommend:
   - keylime
   - tpm2-openssl

--- a/functional/iak-idevid-register-with-certificates/main.fmf
+++ b/functional/iak-idevid-register-with-certificates/main.fmf
@@ -14,6 +14,7 @@ require:
   - xxd
 recommend:
   - keylime
+  - tpm2-openssl
 duration: 5m
 enabled: true
 adjust:

--- a/functional/iak-idevid-register-with-certificates/test.sh
+++ b/functional/iak-idevid-register-with-certificates/test.sh
@@ -141,7 +141,7 @@ rlJournalStart
         rlRun "limeStartAgent"
         # Agent can now register with IDevID and IAK getting verified
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
-        rlAssertGrep "IDevID created" "$(limeAgentLogfile)"
+        rlAssertGrep "(IDevID created|Recreating IDevID)" "$(limeAgentLogfile)" -E
         rlAssertGrep "AK certified with IAK" "$(limeAgentLogfile)"
         # Check the registrar used the IDevID and IAK code block
         rlAssertGrep "INFO - IDevID and IAK received" "$(limeRegistrarLogfile)"

--- a/functional/iak-idevid-register-with-certificates/test.sh
+++ b/functional/iak-idevid-register-with-certificates/test.sh
@@ -137,6 +137,7 @@ rlJournalStart
 
     rlPhaseStartTest "Successful registration - IDevID and IAK certs verified, and IAK verifies AK"
         # Add CA to store
+        rlRun "mkdir -p $TPM_CERTS"
         rlRun "cp ./ca/certs/klca-chain.cert.pem $TPM_CERTS/"
         rlRun "limeStartAgent"
         # Agent can now register with IDevID and IAK getting verified

--- a/regression/CVE-2023-3674/test.sh
+++ b/regression/CVE-2023-3674/test.sh
@@ -79,7 +79,7 @@ rlJournalStart
         rlRun "cat malformed_quote > $ATTESTATION_FILE"
         rlRun -s "keylime_attest" 1
         rlAssertGrep "ERROR - Error verifying quote" "$rlRun_LOG"
-        rlAssertGrep "raise InvalidSignature" "$rlRun_LOG"
+        rlAssertGrep "(raise InvalidSignature|cryptography.exceptions.InvalidSignature)" "$rlRun_LOG" -E
         rlAssertGrep "The following agents failed attestation" "$rlRun_LOG"
     rlPhaseEnd
 

--- a/setup/install_rust_keylime_from_copr/test.sh
+++ b/setup/install_rust_keylime_from_copr/test.sh
@@ -32,7 +32,7 @@ _EOF'
         rlRun "mkdir -p /etc/keylime/agent.conf.d"
         rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
 [Service]
-Environment=\"RUST_LOG=keylime_agent=trace\"
+Environment=\"RUST_LOG=keylime_agent=trace,keylime=trace\"
 _EOF"
         # If the TPM_BINARY_MEASUREMENTS env var is set, set the binary
         # measurements location for the service

--- a/setup/install_upstream_rust_keylime/test.sh
+++ b/setup/install_upstream_rust_keylime/test.sh
@@ -71,7 +71,7 @@ _EOF'
         rlRun "mkdir -p /etc/systemd/system/keylime_agent.service.d"
         rlRun "cat > /etc/systemd/system/keylime_agent.service.d/20-rust_log_trace.conf <<_EOF
 [Service]
-Environment=\"RUST_LOG=keylime_agent=trace\"
+Environment=\"RUST_LOG=keylime_agent=trace,keylime=trace\"
 _EOF"
 
         # If the TPM_BINARY_MEASUREMENTS env var is set, set the binary


### PR DESCRIPTION
This brings the `fedora-40` branch in sync with the `fedora-rawhide` branch.

This cherry picks:

- 0e7afa6ab7cf1f4969f87ad50a5e76dcb75c6243
- da8d7827ca65e6ea0630b3d77d809da5073b294f
- 55a403f0279a22140163e7eebdd311d22a5b4b24
- cfe787dd715e9b167d9d7a8ee165ae0cb59fb89b
- 34ecca32e3b3ba94a0a4c3994ca86f387064714d