### PR TITLE
Restore TPM authorization values on cleanup

### DIFF
--- a/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
+++ b/functional/ek-cert-use-ek_handle-custom-ca_certs/test.sh
@@ -85,6 +85,9 @@ rlJournalStart
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
         rlRun "limeStopIMAEmulator"
+        # changes authorization values back to empty
+        rlRun "tpm2_changeauth -c o -p '$PASSWORD_TPM'"
+        rlRun "tpm2_changeauth -c e -p '$PASSWORD_TPM'"
         rlRun "limeStopTPMEmulator"
         limeSubmitCommonLogs
         rlRun "limeCondStopAbrmd"

--- a/functional/iak-idevid-persisted-and-protected/test.sh
+++ b/functional/iak-idevid-persisted-and-protected/test.sh
@@ -154,6 +154,11 @@ rlJournalStart
     rlPhaseStartCleanup "Do the keylime cleanup"
         rlRun "limeStopAgent"
         rlRun "limeStopRegistrar"
+        # Evict objects made persistent
+        rlRun "tpm2_evictcontrol -c $(cat ikeys/idevid.handle)"
+        rlRun "tpm2_evictcontrol -c $(cat ikeys/iak.handle)"
+        # Set TPM endorsement hierarchy password back to empty
+        rlRun "tpm2_changeauth -c e -p 'hex:00001a2b3c1a2b3c1a2b3c'"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"


### PR DESCRIPTION
For tests that set TPM authorization values, restore the authorization values back to empty on cleanup.

The goal is to avoid the test to interfere on other tests if the same TPM is used.