### PR TITLE
Cherry-pick changes for basic-attestation-on-localhost-api-version-bump from main

### DIFF
--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -11,11 +11,6 @@ rlJournalStart
 
     rlPhaseStartSetup "Do the keylime setup"
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
-        # install recommend devel packages from CRB if missing
-        rpm -q tpm2-tss-devel 2> /dev/null || INSTALL_PKGS="$INSTALL_PKGS tpm2-tss-devel"
-        rpm -q libarchive-devel 2> /dev/null || INSTALL_PKGS="$INSTALL_PKGS libarchive-devel"
-        rpm -q zeromq-devel 2> /dev/null || INSTALL_PKGS="$INSTALL_PKGS zeromq-devel"
-        [ -n "$INSTALL_PKGS" ] && rlRun "dnf --enablerepo \*CRB --enablerepo epel -y install $INSTALL_PKGS"
         rlAssertRpm keylime
 
         # update /etc/keylime.conf
@@ -48,50 +43,23 @@ rlJournalStart
         WORKDIR=$( mktemp -d -p "/var/tmp" )
     rlPhaseEnd
 
-    rlPhaseStartTest "Compile keylime agent with old API version"
-        # Store a backup of the installed binary
-        rlRun "rlFileBackup --namespace agent /usr/bin/keylime_agent"
-        # check if I am running agent from RPM file, i.e. not the upstream one
-        # in this case I am going to use sources from RPM file because
-        # I need to use the right version and extra patches from SRPM may
-        # be necessary
-        if rpm -q keylime-agent-rust && rpm -q --qf '%{VENDOR}' keylime-agent-rust | grep -qv 'Fedora Copr - user packit'; then
-            rlLogInfo "Will use agent sources from SRPM"
-            rlFetchSrcForInstalled keylime-agent-rust
-            rlRun "rpm -i keylime-agent-rust*.src.rpm"
-            rlRun "dnf -y builddep ~/rpmbuild/SPECS/keylime-agent-rust.spec"
-            rlRun "rpmbuild -bp ~/rpmbuild/SPECS/keylime-agent-rust.spec --nodeps --define '_builddir $PWD'" 0,1
-            if ls -d keylime-agent-rust*build; then
-                rlRun "pushd keylime-agent-rust*build/rust-keylime*"
-            else
-                rlRun "rm -rf rust-keylime-*SPECPARTS"
-                rlRun "pushd rust-keylime*"
-            fi
-        else
-            rlLogInfo "Will use agent sources from upstream repo"
-            rlRun "git clone ${RUST_KEYLIME_UPSTREAM_URL} ${WORKDIR}/rust-keylime"
-            rlRun "pushd ${WORKDIR}/rust-keylime"
+    rlPhaseStartTest "Get agent supported versions"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+        mapfile -t SUPPORTED_VERSIONS< <(grep -ohE '> Starting server with API version.*' "$(limeAgentLogfile)" | grep -ohE '[0-9]*\.[0-9]*' | sort -V)
+        if [[ "${#SUPPORTED_VERSIONS[@]}" -lt 2 ]]; then
+            rlFail "Agent supports only one API version: ${SUPPORTED_VERSIONS[*]}"
         fi
-        # Get a supported version older than the current
-        CURRENT_VERSION="$(grep -E '(^.*API_VERSION.*v)([0-9]+\.[0-9]+)' keylime-agent/src/common.rs | grep -o -E '[0-9]+\.[0-9]+')"
-        OLD_VERSION="$(grep -o -E "Supported older API versions: .*" "$(limeVerifierLogfile)" | grep -o -E '[0-9]+\.[0-9]+' | sed -n "1,/^$CURRENT_VERSION\$/ p" | grep -v "^$CURRENT_VERSION\$" | tail -1)"
-
-        # Replace the API version to fake an older version
-        rlRun "cp keylime-agent/src/common.rs keylime-agent/src/common.rs.backup"
-        rlRun "sed -i -E \"s/(^.*API_VERSION.*v)([0-9]+\.[0-9]+)/\1$OLD_VERSION/\" keylime-agent/src/common.rs"
-        rlRun "diff keylime-agent/src/common.rs.backup keylime-agent/src/common.rs" 1
-        # Replace agent binary
-        rlRun "cargo build"
+        rlLog "Agent supported versions: ${SUPPORTED_VERSIONS[*]}"
+        OLD_VERSION=${SUPPORTED_VERSIONS[0]}
+        LATEST_VERSION=${SUPPORTED_VERSIONS[${#SUPPORTED_VERSIONS[@]} -1]}
         rlRun "limeStopAgent"
-        BUILDDIR=$PWD
-        rlRun "cp ${BUILDDIR}/target/debug/keylime_agent /usr/bin/keylime_agent"
-        rlRun "popd"
     rlPhaseEnd
 
     rlPhaseStartTest "Add keylime agent with old API version"
+        rlRun "limeUpdateConf agent api_versions \"\\\"${OLD_VERSION}\\\"\""
         rlRun "limeStartAgent"
-        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
-        rlAssertGrep "Starting server with API version v${OLD_VERSION}" "$(limeAgentLogfile)" -E
+        rlAssertGrep "Starting server with API versions: ${OLD_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "cat > script.expect <<_EOF
 set timeout 20
 spawn keylime_tenant -v 127.0.0.1 -t 127.0.0.1 -u $AGENT_ID --verify --runtime-policy policy.json --cert default -c add
@@ -108,8 +76,9 @@ _EOF"
 
     rlPhaseStartTest "Verify that API version is automatically bumped"
         rlRun "limeStopAgent"
-        rlRun "rlFileRestore --namespace agent"
+        rlRun "limeUpdateConf agent api_versions \"\\\"${LATEST_VERSION}\\\"\""
         rlRun "limeStartAgent"
+        rlAssertGrep "Starting server with API versions: ${LATEST_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "rlWaitForCmd 'tail \$(limeVerifierLogfile) | grep -q \"Agent $AGENT_ID API version updated\"' -m 10 -d 1 -t 10"
         rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
         rlRun -s "keylime_tenant -c cvlist"
@@ -118,8 +87,9 @@ _EOF"
 
     rlPhaseStartTest "Verify that API version downgrade is not allowed"
         rlRun "limeStopAgent"
-        rlRun "cp ${BUILDDIR}/target/debug/keylime_agent /usr/bin/keylime_agent"
+        rlRun "limeUpdateConf agent api_versions \"\\\"${OLD_VERSION}\\\"\""
         rlRun "limeStartAgent"
+        rlAssertGrep "Starting server with API versions: ${OLD_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - Agent $AGENT_ID API version $OLD_VERSION is lower or equal to previous version" "$(limeVerifierLogfile)"
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" "$(limeVerifierLogfile)"
@@ -127,7 +97,6 @@ _EOF"
 
     rlPhaseStartCleanup "Do the keylime cleanup"
         rlRun "limeStopAgent"
-        rlRun "rlFileRestore --namespace agent"
         rlRun "limeStopRegistrar"
         rlRun "limeStopVerifier"
         if limeTPMEmulated; then

--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -55,7 +55,7 @@ rlJournalStart
         # in this case I am going to use sources from RPM file because
         # I need to use the right version and extra patches from SRPM may
         # be necessary
-        if rpm -q keylime-agent-rust; then
+        if rpm -q keylime-agent-rust && rpm -q --qf '%{VENDOR}' keylime-agent-rust | grep -qv 'Fedora Copr - user packit'; then
             rlLogInfo "Will use agent sources from SRPM"
             rlFetchSrcForInstalled keylime-agent-rust
             rlRun "rpm -i keylime-agent-rust*.src.rpm"

--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -59,8 +59,14 @@ rlJournalStart
             rlLogInfo "Will use agent sources from SRPM"
             rlFetchSrcForInstalled keylime-agent-rust
             rlRun "rpm -i keylime-agent-rust*.src.rpm"
+            rlRun "dnf -y builddep ~/rpmbuild/SPECS/keylime-agent-rust.spec"
             rlRun "rpmbuild -bp ~/rpmbuild/SPECS/keylime-agent-rust.spec --nodeps --define '_builddir $PWD'" 0,1
-            rlRun "pushd keylime-agent-rust*build/rust-keylime*"
+            if ls -d keylime-agent-rust*build; then
+                rlRun "pushd keylime-agent-rust*build/rust-keylime*"
+            else
+                rlRun "rm -rf rust-keylime-*SPECPARTS"
+                rlRun "pushd rust-keylime*"
+            fi
         else
             rlLogInfo "Will use agent sources from upstream repo"
             rlRun "git clone ${RUST_KEYLIME_UPSTREAM_URL} ${WORKDIR}/rust-keylime"

--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -59,6 +59,7 @@ rlJournalStart
     rlPhaseStartTest "Add keylime agent with old API version"
         rlRun "limeUpdateConf agent api_versions \"\\\"${OLD_VERSION}\\\"\""
         rlRun "limeStartAgent"
+        sleep 3
         rlAssertGrep "Starting server with API versions: ${OLD_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "cat > script.expect <<_EOF
 set timeout 20
@@ -78,6 +79,7 @@ _EOF"
         rlRun "limeStopAgent"
         rlRun "limeUpdateConf agent api_versions \"\\\"${LATEST_VERSION}\\\"\""
         rlRun "limeStartAgent"
+        sleep 3
         rlAssertGrep "Starting server with API versions: ${LATEST_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "rlWaitForCmd 'tail \$(limeVerifierLogfile) | grep -q \"Agent $AGENT_ID API version updated\"' -m 10 -d 1 -t 10"
         rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
@@ -89,6 +91,7 @@ _EOF"
         rlRun "limeStopAgent"
         rlRun "limeUpdateConf agent api_versions \"\\\"${OLD_VERSION}\\\"\""
         rlRun "limeStartAgent"
+        sleep 3
         rlAssertGrep "Starting server with API versions: ${OLD_VERSION}$" "$(limeAgentLogfile)" -E
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
         rlAssertGrep "WARNING - Agent $AGENT_ID API version $OLD_VERSION is lower or equal to previous version" "$(limeVerifierLogfile)"

--- a/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/test.sh
@@ -46,7 +46,7 @@ rlJournalStart
     rlPhaseStartTest "Get agent supported versions"
         rlRun "limeStartAgent"
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
-        mapfile -t SUPPORTED_VERSIONS< <(grep -ohE '> Starting server with API version.*' "$(limeAgentLogfile)" | grep -ohE '[0-9]*\.[0-9]*' | sort -V)
+        mapfile -t SUPPORTED_VERSIONS< <(grep -ohE '> Starting server with API version.*' "$(limeAgentLogfile)" | grep -ohE '[0-9]+\.[0-9]+' | sort -V)
         if [[ "${#SUPPORTED_VERSIONS[@]}" -lt 2 ]]; then
             rlFail "Agent supports only one API version: ${SUPPORTED_VERSIONS[*]}"
         fi

--- a/plans/distribution-fedora-keylime.fmf
+++ b/plans/distribution-fedora-keylime.fmf
@@ -27,6 +27,7 @@ discover:
    - /setup/inject_SELinux_AVC_check
    - "^/functional/.*"
    - "^/regression/.*"
+   - "^/compatibility/.*"
 
 execute:
     how: tmt

--- a/setup/generate_coverage_report/patchcov.py
+++ b/setup/generate_coverage_report/patchcov.py
@@ -184,7 +184,7 @@ def get_patch_coverage(patch_path, db_path):
     for row in table_context:
         if row[0] in contexts_used:
             prefix = get_test_code(row[0])
-            name = re.sub('^.*\/discover\/[^/]*\/tests', '', row[1])
+            name = re.sub(r'^.*/discover/[^/]*/tests', '', row[1])
             print('  {}  {}'.format(prefix, name))
     print()
 


### PR DESCRIPTION
This updates the test on `fedora-42` to work with the agent with multiple API versions