### PR TITLE
Add option to double test duration

### DIFF
--- a/Multihost/main.fmf
+++ b/Multihost/main.fmf
@@ -1,0 +1,1 @@
+../functional/main.fmf

--- a/compatibility/main.fmf
+++ b/compatibility/main.fmf
@@ -1,0 +1,1 @@
+../functional/main.fmf

--- a/container/main.fmf
+++ b/container/main.fmf
@@ -1,0 +1,1 @@
+../functional/main.fmf

--- a/functional/main.fmf
+++ b/functional/main.fmf
@@ -1,0 +1,3 @@
+adjust+:
+  - duration+: "*2"
+    when: double_test_duration is defined

--- a/regression/main.fmf
+++ b/regression/main.fmf
@@ -1,0 +1,1 @@
+../functional/main.fmf

--- a/setup/main.fmf
+++ b/setup/main.fmf
@@ -1,0 +1,1 @@
+../functional/main.fmf


### PR DESCRIPTION
By defining `double_test_duration` context on `tmt` command line we can double test duration. This is handy especially for slow test systems.