### PR TITLE
Enable logs generated by the keylime library

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -479,8 +479,9 @@ __limeStartKeylimeService() {
 
     # if there is no unit file, execute the process directly
     else
-        # export RUST_LOG=keylime_agent=trace just in case we are using rust-keylime
-        RUST_LOG=keylime_agent=trace
+        # export RUST_LOG=keylime_agent=trace,keylime=trace just in case we are
+        # using rust-keylime
+        RUST_LOG=keylime_agent=trace,keylime=trace
         echo "running: keylime_${NAME} ${ARGS} >> ${LOGFILE} 2>&1 &"
         keylime_${NAME} ${ARGS} >> ${LOGFILE} 2>&1 &
     fi

--- a/regression/keylime-agent-option-override-through-envvar/test.sh
+++ b/regression/keylime-agent-option-override-through-envvar/test.sh
@@ -26,7 +26,7 @@ rlJournalStart
 
     rlPhaseStartTest "Start keylime agent"
         rlRun -s "RUST_LOG=debug KEYLIME_AGENT_REGISTRAR_IP=1.2.3.4 timeout 5 keylime_agent" 0-255
-        rlAssertGrep "DEBUG keylime_agent::config > Environment configuration registrar_ip=1.2.3.4" $rlRun_LOG
+        rlAssertGrep "Environment configuration registrar_ip=1.2.3.4" $rlRun_LOG
         rlAssertGrep "connecting to 1.2.3.4" $rlRun_LOG
         rlAssertNotGrep "connecting to 127.0.0.1" $rlRun_LOG
     rlPhaseEnd

--- a/sanity/keylime-secure_mount/test.sh
+++ b/sanity/keylime-secure_mount/test.sh
@@ -43,7 +43,7 @@ rlJournalStart
         rlRun "systemctl daemon-reload"
         rlRun "limeStartAgent"
         sleep 3
-        rlAssertGrep "INFO  keylime_agent::secure_mount > Directory \"$SECURE_DIR\" created" $(limeAgentLogfile)
+        rlAssertGrep "secure_mount > Directory \"$SECURE_DIR\" created" $(limeAgentLogfile)
         #verify that the mount point has been created and tmpfs mounted
         rlRun "findmnt -M \"$SECURE_DIR\" -t tmpfs"
         rlRun "limeStopAgent"
@@ -53,7 +53,7 @@ rlJournalStart
     rlPhaseStartTest "Manual mount dir with wrong fs, agent fail"
         rlRun "mount -t ramfs -o size=1m,mode=0700 ramfs $SECURE_DIR"
         rlRun "limeStartAgent"
-        rlAssertGrep "ERROR keylime_agent::secure_mount > Secure mount error: Secure storage location $SECURE_DIR already mounted on wrong file system type:" $(limeAgentLogfile)
+        rlAssertGrep "secure_mount > Secure mount error: Secure storage location $SECURE_DIR already mounted on wrong file system type:" $(limeAgentLogfile)
         rlRun "limeStopAgent"
         rlRun "umount $SECURE_DIR"
     rlPhaseEnd


### PR DESCRIPTION
The PR https://github.com/keylime/rust-keylime/pull/1018 moves code from the `keylime-agent` application to the `keylime` library.

This makes it necessary to set the log level for both the application and the library so that the messages are logged as expected.

This also changes the `sanity/keylime-secure_mount` test to ignore the source of the expected log. 