### PR TITLE
Adjust test scenario to use sign PQC algoritms

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -1676,6 +1676,106 @@ END
 true <<'=cut'
 =pod
 
+=head2 limeGeneratePrivateKeyForCertsign
+
+Generates a private key for various algorithms like RSA, EC, and others. The
+key is stored in a directory named after the provided alias.
+
+    # Generate a 4096-bit RSA key
+    limeGeneratePrivateKeyForCertsign "my-rsa-alias" "RSA" 4096
+
+    # Generate an ECDSA key with a specific curve
+    limeGeneratePrivateKeyForCertsign "my-ec-alias" "EC" "secp384r1"
+
+    # Generate an ECDSA key with the default curve (prime256v1)
+    limeGeneratePrivateKeyForCertsign "my-default-ec-alias" "ECDSA"
+
+    # Generate an Ed25519 key (no parameters needed)
+    limeGeneratePrivateKeyForCertsign "my-ed25519-alias" "ED25519"
+
+The function creates a directory based on the alias and places the generated
+private key file, named `key.pem`, within it.
+
+=over
+
+=item alias
+
+The first argument, a mandatory string that serves as an alias for the key.
+A directory with this name will be created to store the key file.
+
+=item algorithm
+
+The second argument, a mandatory string specifying the cryptographic algorithm
+for the key generation (e.g., "RSA", "EC", "ECDSA", "ED25519"). The algorithm
+name must be one that is recognized by `openssl genpkey` or `openssl genrsa`.
+
+=item params
+
+An optional third argument whose meaning depends on the chosen algorithm.
+
+=over
+
+=item *
+
+For B<RSA>, this specifies the key size in bits. Defaults to C<2048>.
+
+=item *
+
+For B<EC> or B<ECDSA>, this specifies the curve name (e.g., C<secp384r1>).
+Defaults to C<prime256v1>.
+
+=item *
+
+For other algorithms like B<ED25519> or B<ML-DSA-65>, this parameter is
+typically unused.
+
+=back
+
+=back
+
+Returns 0 on successful key generation, and a non-zero value otherwise.
+
+=cut
+
+limeGeneratePrivateKeyForCertsign() {
+    local alias="$1"
+    local algorithm="$2"
+    local params="$3"
+    local cmd
+
+    if ! mkdir -p "$alias"; then
+        rlLog "Failed to create directory for alias '$alias'"
+        return 1
+    fi
+
+    local key_path="$alias/key.pem"
+
+    case "$algorithm" in
+        "RSA")
+            local rsa_bits="${params:-2048}"
+            cmd="openssl genrsa -out \"$key_path\" $rsa_bits"
+            ;;
+
+        "EC" | "ECDSA")
+            # For ECDSA, the parameter is the curve name. Default to a common, secure curve.
+            local curve="${params:-prime256v1}"
+            cmd="openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:\"$curve\" -out \"$key_path\""
+            ;;
+
+        *)
+            # For modern algorithms like ML-DSA-65, ED25519, etc.
+            # These often don't require extra parameters.
+            cmd="openssl genpkey -algorithm \"$algorithm\" -out \"$key_path\""
+            ;;
+    esac
+
+    # Assuming rlRun is a helper function you have defined elsewhere.
+    rlRun "$cmd" 0 "Generate private key ($algorithm) -> $alias"
+}
+
+true <<'=cut'
+=pod
+
 =head2 limeCreateTestPolicy
 
 Creates policy.json to be used for testing purposes.

--- a/functional/basic-attestation-with-custom-certificates/main.fmf
+++ b/functional/basic-attestation-with-custom-certificates/main.fmf
@@ -28,4 +28,18 @@ recommend:
 duration: 15m
 enabled: true
 extra-nitrate: TC#0611725
-id: 81d1da23-9e06-4d2c-b6fe-14df6786c4b0
+/ecdsa:
+    environment:
+        CRYPTO_ALG: ECDSA
+/rsa:
+    environment:
+        CRYPTO_ALG: RSA
+    id: 81d1da23-9e06-4d2c-b6fe-14df6786c4b0
+/pqc_alg:
+    environment:
+        CRYPTO_ALG: ML-DSA-65
+    continue: false
+    adjust+:
+      - enabled: false
+        when: distro < rhel-10.1 or distro < fedora-43
+        because: PQC is available from this version of OS

--- a/functional/basic-attestation-with-custom-certificates/test.sh
+++ b/functional/basic-attestation-with-custom-certificates/test.sh
@@ -29,13 +29,24 @@ rlJournalStart
         # tenant = webclient cert used (twice) by the tenant, running on AGENT server
         # webhook = webserver cert used for the revocation notification webhook
         # btw, we could live with just one key instead of generating multiple keys.. but that's just how openssl/certgen works
-        rlRun "x509KeyGen ca" 0 "Generating Root CA RSA key pair"
-        rlRun "x509KeyGen intermediate-ca" 0 "Generating Intermediate CA RSA key pair"
-        rlRun "x509KeyGen verifier" 0 "Generating verifier RSA key pair"
-        rlRun "x509KeyGen verifier-client" 0 "Generating verifier-client RSA key pair"
-        rlRun "x509KeyGen registrar" 0 "Generating registrar RSA key pair"
-        rlRun "x509KeyGen tenant" 0 "Generating tenant RSA key pair"
-        rlRun "x509KeyGen webhook" 0 "Generating webhook RSA key pair"
+
+        limeGeneratePrivateKeyForCertsign "ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "intermediate-ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "verifier" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "verifier-client" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "registrar" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "tenant" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "webhook" "${CRYPTO_ALG}" 
+
+        # Library doesn't support generation of PQC algorithms
+        # Generate keys for TLS certificates
+        #rlRun "x509KeyGen ca" 0 "Generating Root CA RSA key pair"
+        #rlRun "x509KeyGen intermediate-ca" 0 "Generating Intermediate CA RSA key pair"
+        #rlRun "x509KeyGen verifier" 0 "Generating verifier RSA key pair"
+        #rlRun "x509KeyGen verifier-client" 0 "Generating verifier-client RSA key pair"
+        #rlRun "x509KeyGen registrar" 0 "Generating registrar RSA key pair"
+        #rlRun "x509KeyGen tenant" 0 "Generating tenant RSA key pair"
+        #rlRun "x509KeyGen webhook" 0 "Generating webhook RSA key pair"
         #rlRun "x509KeyGen agent" 0 "Preparing RSA tenant certificate"
         rlRun "x509SelfSign ca" 0 "Selfsigning Root CA certificate"
         rlRun "x509CertSign --CA ca --DN 'CN = ${HOSTNAME}' -t CA --subjectAltName 'IP = ${MY_IP}' intermediate-ca" 0 "Signing intermediate CA certificate with our Root CA key"

--- a/functional/webhook-certificate-on-localhost/main.fmf
+++ b/functional/webhook-certificate-on-localhost/main.fmf
@@ -28,3 +28,17 @@ recommend:
   - python3-tomli
 duration: 10m
 enabled: true
+/ecdsa:
+    environment:
+        CRYPTO_ALG: ECDSA
+/rsa:
+    environment:
+        CRYPTO_ALG: RSA
+/pqc_alg:
+    environment:
+        CRYPTO_ALG: ML-DSA-65
+    continue: false
+    adjust+:
+      - enabled: false
+        when: distro < rhel-10.1 or distro < fedora-43
+        because: PQC is available from this version of OS

--- a/functional/webhook-certificate-on-localhost/test.sh
+++ b/functional/webhook-certificate-on-localhost/test.sh
@@ -24,18 +24,31 @@ rlJournalStart
         CERTDIR=/var/lib/keylime/certs
         rlRun "mkdir -p $CERTDIR"
 
+        limeGeneratePrivateKeyForCertsign "good-ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "bad-ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "installed-ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "intermediate-ca" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "verifier" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "verifier-client" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "registrar" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "tenant" "${CRYPTO_ALG}"
+        limeGeneratePrivateKeyForCertsign "good-webhook" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "bad-webhook" "${CRYPTO_ALG}" 
+        limeGeneratePrivateKeyForCertsign "installed-webhook" "${CRYPTO_ALG}"
+
+        # Library doesn't support generation of PQC algorithms
         # Generate keys for TLS certificates
-        rlRun "x509KeyGen good-ca" 0 "Generating good CA RSA key pair"
-        rlRun "x509KeyGen bad-ca" 0 "Generating bad CA RSA key pair"
-        rlRun "x509KeyGen installed-ca" 0 "Generating installed CA RSA key pair"
-        rlRun "x509KeyGen intermediate-ca" 0 "Generating Intermediate CA RSA key pair"
-        rlRun "x509KeyGen verifier" 0 "Generating verifier RSA key pair"
-        rlRun "x509KeyGen verifier-client" 0 "Generating verifier-client RSA key pair"
-        rlRun "x509KeyGen registrar" 0 "Generating registrar RSA key pair"
-        rlRun "x509KeyGen tenant" 0 "Generating tenant RSA key pair"
-        rlRun "x509KeyGen good-webhook" 0 "Generating webhook RSA key pair"
-        rlRun "x509KeyGen bad-webhook" 0 "Generating bad webhook RSA key pair"
-        rlRun "x509KeyGen installed-webhook" 0 "Generating installed webhook RSA key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} good-ca" 0 "Generating good CA ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} bad-ca" 0 "Generating bad CA ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} installed-ca" 0 "Generating installed CA ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} intermediate-ca" 0 "Generating Intermediate CA ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} verifier" 0 "Generating verifier ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} verifier-client" 0 "Generating verifier-client ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} registrar" 0 "Generating registrar ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} tenant" 0 "Generating tenant ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} good-webhook" 0 "Generating webhook ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} bad-webhook" 0 "Generating bad webhook ${CRYPTO_ALG} key pair"
+        #rlRun "x509KeyGen -t ${CRYPTO_ALG} installed-webhook" 0 "Generating installed webhook ${CRYPTO_ALG} key pair"
 
         # Sign good certificates for each component and the webhook
         rlRun "x509SelfSign good-ca --DN 'CN = goodCA'" 0 "Selfsigning good CA certificate"


### PR DESCRIPTION
Two current scenarios use as default sign algorithm RSA, adjust these to make it configurable to use RSA or ML-DSA-65. Part of this change is implementing function for key generation, current certgen library cannot generate PQ algorithm.