### PR TITLE
Update expected error due to keylime PR#1784

### DIFF
--- a/functional/webhook-certificate-on-localhost/test.sh
+++ b/functional/webhook-certificate-on-localhost/test.sh
@@ -185,7 +185,7 @@ _EOF"
                 # We expect the verifier was not successful to connect to the
                 # webhook. The webhook should not receive the notification.
                 rlAssertGrep "Sending revocation event via webhook to https://localhost:${WEBHOOK_SERVER_PORT}" "$(limeVerifierLogfile)"
-                rlAssertGrep "requests.exceptions.SSLError: HTTPSConnectionPool\(host='localhost', port=${WEBHOOK_SERVER_PORT}.*${EXPECTED_ERROR}" "$(limeVerifierLogfile)" -E || (cat "$(limeVerifierLogfile)" && cat "${WEBHOOK_SERVER_LOG}")
+                rlAssertGrep "HTTPSConnectionPool\(host='localhost', port=${WEBHOOK_SERVER_PORT}.*${EXPECTED_ERROR}" "$(limeVerifierLogfile)" -E || (cat "$(limeVerifierLogfile)" && cat "${WEBHOOK_SERVER_LOG}")
                 rlAssertNotGrep "\\\\\"type\\\\\": \\\\\"revocation\\\\\", \\\\\"ip\\\\\": \\\\\"127.0.0.1\\\\\", \\\\\"agent_id\\\\\": \\\\\"${AGENT_ID}\\\\\"" "${WEBHOOK_SERVER_LOG}" -i
             else
                 # We expect the verifier was successful connecting to the


### PR DESCRIPTION
Shortening the check for an error message to make it compatible both with the old code and the new code introduced in https://github.com/keylime/keylime/pull/1784.