### PR TITLE
Fix pattern for keylime process detection

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -491,7 +491,7 @@ __limeProcesses() {
     local NAME=$1
 
     pgrep -af "${NAME}([[:space:]]|\$)" \
-       | grep "/${NAME}" | grep -v grep
+       | grep "[^[:alnum:]-]${NAME}" | grep -v grep
 }
 
 __limePIDs() {


### PR DESCRIPTION
Processes like keylime_ima_emulator do not have / before its name in process listing.