### PR TITLE
Set TCTI variables during swtpm device setup

### DIFF
--- a/Library/test-helpers/Dockerfile.agent
+++ b/Library/test-helpers/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
   curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \

--- a/Library/test-helpers/Dockerfile.registrar
+++ b/Library/test-helpers/Dockerfile.registrar
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
   curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \

--- a/Library/test-helpers/Dockerfile.tenant
+++ b/Library/test-helpers/Dockerfile.tenant
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
   curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \

--- a/Library/test-helpers/Dockerfile.upstream.c10s
+++ b/Library/test-helpers/Dockerfile.upstream.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 COPY lime_con_install_upstream.sh /usr/local/bin/lime_con_install_upstream
 RUN \
     rm -f /etc/yum.repos.d/centos.repo && \

--- a/Library/test-helpers/Dockerfile.verifier
+++ b/Library/test-helpers/Dockerfile.verifier
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
   curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \

--- a/Library/test-helpers/Dockerfile.webhook
+++ b/Library/test-helpers/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 
 RUN dnf makecache && \
     dnf install -y openssl && \

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -454,12 +454,13 @@ limeClearData() {
 __limeGetLogName() {
     local NAME=$1
     local LOGSUFFIX
+    local TPMSUFFIX
     [ -n "$2" ] && LOGSUFFIX="$2" || LOGSUFFIX=$( echo "$NAME" | sed 's/.*/\u&/' )  # just uppercase first letter
     local LOGNAME=__INTERNAL_limeLog${LOGSUFFIX}
     if [ "$NAME" == "ima_emulator" ] && [ "$limeTPMDevNo" != "0" ]; then
-        LOGNAME=${LOGNAME}.tpm${limeTPMDevNo}
+        TPMSUFFIX=".tpm${limeTPMDevNo}"
     fi
-    echo ${!LOGNAME}
+    echo ${!LOGNAME}${TPMSUFFIX}
 }
 
 __limeStartKeylimeService() {

--- a/container/compatibility/registrar_version_compatibility/Dockerfile.keylime.c10s
+++ b/container/compatibility/registrar_version_compatibility/Dockerfile.keylime.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 RUN \
   rm -f /etc/yum.repos.d/centos.repo && \
   curl -o /etc/yum.repos.d/c10s.repo 'https://raw.githubusercontent.com/RedHat-SP-Security/keylime-tests/main/tools/c10s.repo' && \

--- a/container/compatibility/registrar_version_compatibility/Dockerfile.upstream.c10s
+++ b/container/compatibility/registrar_version_compatibility/Dockerfile.upstream.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 COPY lime_con_install_upstream.sh /usr/local/bin/lime_con_install_upstream
 RUN \
     rm -f /etc/yum.repos.d/centos.repo && \

--- a/container/functional/keylime_agent_container-basic-attestation/test.sh
+++ b/container/functional/keylime_agent_container-basic-attestation/test.sh
@@ -46,7 +46,7 @@ rlJournalStart
         rlRun "limeTPMDevNo=1 limeStartTPMEmulator"
         rlRun "limeTPMDevNo=1 limeWaitForTPMEmulator"
         # start ima emulator
-        rlRun "limeTPMDevNo=1 TCTI=device:/dev/tpm1 limeStartIMAEmulator"
+        rlRun "limeTPMDevNo=1 TCTI=device:/dev/tpmrm1 limeStartIMAEmulator"
  
         sleep 5
 

--- a/plans/upstream-keylime-containers.fmf
+++ b/plans/upstream-keylime-containers.fmf
@@ -23,16 +23,7 @@ discover:
    # this is to utilize also a different parser
    - /setup/configure_kernel_ima_module/ima_policy_simple
    #- /setup/inject_SELinux_AVC_check
-   - "/container/functional/.*"
-   - "/container/compatibility/.*"
+   - "/container/functional/keylime_agent_container-basic-attestation"
 
 execute:
     how: tmt
-
-adjust+:
-  - when: target_PR_branch is defined and target_PR_branch != main
-    enabled: false
-    because: we want to run this plan only for PRs targeting the main branch
-
-  - when: distro != fedora-41 and distro != centos-stream-10
-    enabled: false

--- a/setup/configure_swtpm_device/test.sh
+++ b/setup/configure_swtpm_device/test.sh
@@ -97,7 +97,7 @@ _EOF"
     rlPhaseEnd
 
     rlPhaseStartTest "Test TPM emulator"
-        rlRun -s "TPM2TOOLS_TCTI=device:/dev/tpm${NEW_TPM_DEV_NO} tpm2_pcrread"
+        rlRun -s "TPM2TOOLS_TCTI=device:/dev/tpmrm${NEW_TPM_DEV_NO} tpm2_pcrread"
         rlAssertGrep "0 : 0x0000000000000000000000000000000000000000" $rlRun_LOG
     rlPhaseEnd
 


### PR DESCRIPTION
Configure `TCTI` and `TPM2TOOLS_TCTI` variables in `/setup/configure_swtpm_device` task both for the pull and push based agents but only if some other `/dev/tpm` device hasn't been configured already.
Similar setup is already being made in `/setup/configure_tpm_emulator` task.