### PR TITLE
Do not register as rust-agent CI test

### DIFF
--- a/regression/db-connection-leak-reproducer/main.fmf
+++ b/regression/db-connection-leak-reproducer/main.fmf
@@ -28,6 +28,7 @@ framework: beakerlib
 tag:
   - regression
   - database
+  - not-agent-upstream-CI
 require:
   - yum
   - expect


### PR DESCRIPTION
Do not register /regression/db-connection-leak-reproducer as a Rust agent CI test.