### PR TITLE
Backport/20250919 38820 rhel 9 main

### DIFF
--- a/regression/keylime-agent-option-override-through-envvar/test.sh
+++ b/regression/keylime-agent-option-override-through-envvar/test.sh
@@ -25,8 +25,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Start keylime agent"
-        rlRun -s "RUST_LOG=debug KEYLIME_AGENT_REGISTRAR_IP=1.2.3.4 timeout 5 keylime_agent" 0-255
-        rlAssertGrep "DEBUG keylime_agent::config > Environment configuration registrar_ip=1.2.3.4" $rlRun_LOG
+        rlRun -s "RUST_LOG=debug KEYLIME_AGENT_REGISTRAR_IP=1.2.3.4 timeout ${limeTIMEOUT} keylime_agent" 0-255
+        rlAssertGrep "Environment configuration registrar_ip=1.2.3.4" $rlRun_LOG
         rlAssertGrep "connecting to 1.2.3.4" $rlRun_LOG
         rlAssertNotGrep "connecting to 127.0.0.1" $rlRun_LOG
     rlPhaseEnd


### PR DESCRIPTION
## Summary by Sourcery

Enhance test reliability by increasing wait times and adding explicit agent registration and status checks in the basic attestation API version bump tests, and parameterize timeout and simplify log assertion in the agent option override test.

Tests:
- Increase sleep intervals and add limeWaitForAgentRegistration and limeWaitForAgentStatus calls in basic-attestation-on-localhost-api-version-bump test script
- Replace hardcoded timeout with ${limeTIMEOUT} and adjust log assertion to match environment configuration line in keylime-agent-option-override-through-envvar test