### PR TITLE
Wait a bit longer for agent to start

### DIFF
--- a/compatibility/api_version_compatibility/test.sh
+++ b/compatibility/api_version_compatibility/test.sh
@@ -50,7 +50,9 @@ rlJournalStart
         rlPhaseStartTest "Add keylime agent with API version ${VERSION}"
             rlRun "limeUpdateConf agent api_versions \"\\\"${VERSION}\\\"\""
             rlRun "limeStartAgent"
-            sleep 3
+            # starting agent with HW TPM may take longer
+            sleep 10
+            rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
             #rlAssertGrep "Starting server with API versions: ${VERSION}$" "$(limeAgentLogfile)" -E
             rlRun "cat > script.expect <<_EOF
 set timeout 20


### PR DESCRIPTION
## Summary by Sourcery

Improve reliability of agent startup in API version compatibility tests by extending the wait and explicitly waiting for registration

Tests:
- Increase the sleep duration from 3 to 10 seconds in the compatibility test to accommodate hardware TPM startup
- Add an explicit wait command for agent registration after starting the agent