### PR TITLE
Use custom certificates for the agent too

### DIFF
--- a/functional/basic-attestation-with-custom-certificates/main.fmf
+++ b/functional/basic-attestation-with-custom-certificates/main.fmf
@@ -39,6 +39,7 @@ extra-nitrate: TC#0611725
 /pqc_alg:
     environment:
         CRYPTO_ALG: mldsa65
+        AGENT_CRYPTO_ALG: ecdsa
     continue: false
     adjust+:
       - enabled: false


### PR DESCRIPTION
Previously, the agent supported only RSA key/certificate as the mTLS key because it was also used to encrypt data in the secure payload mechanism.

With https://github.com/keylime/rust-keylime/pull/1129, the agent is now able to use different algorithms for mTLS.

## Summary by Sourcery

Enable functional tests to generate and configure custom agent certificates for mTLS using the specified cryptographic algorithm

Tests:
- Generate agent key pair with CRYPTO_ALG instead of default RSA
- Sign the agent certificate with the intermediate CA
- Copy agent certificate and key into the test certificate directory
- Update agent configuration in tests to reference full paths for the server_cert and server_key