### PR TITLE
Add RHEL ubi dockerfiles

### DIFF
--- a/Library/test-helpers/Dockerfile.agent.ubi
+++ b/Library/test-helpers/Dockerfile.agent.ubi
@@ -1,0 +1,12 @@
+FROM docker.io/redhat/ubi10
+COPY yumrepogen_setup.sh /root/yumrepogen_setup.sh
+RUN \
+  chmod a+x /root/yumrepogen_setup.sh && /root/yumrepogen_setup.sh && \
+  cat /etc/yum.repos.d/* && \
+  dnf install -y --skip-broken keylime-agent-rust keylime-agent-rust-push util-linux-core which && \
+  dnf clean all
+
+EXPOSE 9002
+EXPOSE 8892
+
+CMD ["keylime_agent"]

--- a/Library/test-helpers/Dockerfile.registrar.ubi
+++ b/Library/test-helpers/Dockerfile.registrar.ubi
@@ -1,0 +1,12 @@
+FROM docker.io/redhat/ubi10
+COPY yumrepogen_setup.sh /root/yumrepogen_setup.sh
+RUN \
+  chmod a+x /root/yumrepogen_setup.sh && /root/yumrepogen_setup.sh && \
+  cat /etc/yum.repos.d/* && \
+  dnf install -y keylime-registrar which && \
+  dnf clean all
+
+EXPOSE 8890
+EXPOSE 8891
+
+CMD ["keylime_registrar"]

--- a/Library/test-helpers/Dockerfile.systemd.ubi
+++ b/Library/test-helpers/Dockerfile.systemd.ubi
@@ -1,0 +1,12 @@
+FROM docker.io/redhat/ubi10
+COPY yumrepogen_setup.sh /root/yumrepogen_setup.sh
+COPY id_*.pub /root/
+RUN \
+  chmod a+x /root/yumrepogen_setup.sh && /root/yumrepogen_setup.sh && \
+  cat /etc/yum.repos.d/* && \
+  dnf install -y systemd util-linux-core openssh openssh-server && \
+  ssh-keygen -A && \
+  mkdir -p /root/.ssh && \
+  cat /root/id_*.pub > /root/.ssh/authorized_keys && \
+  chmod 700 /root/.ssh/authorized_keys
+CMD ["/sbin/init"]

--- a/Library/test-helpers/Dockerfile.tenant.ubi
+++ b/Library/test-helpers/Dockerfile.tenant.ubi
@@ -1,0 +1,7 @@
+FROM docker.io/redhat/ubi10
+COPY yumrepogen_setup.sh /root/yumrepogen_setup.sh
+RUN \
+  chmod a+x /root/yumrepogen_setup.sh && /root/yumrepogen_setup.sh && \
+  cat /etc/yum.repos.d/* && \
+  dnf install -y keylime-tenant which && \
+  dnf clean all

--- a/Library/test-helpers/Dockerfile.verifier.ubi
+++ b/Library/test-helpers/Dockerfile.verifier.ubi
@@ -1,0 +1,11 @@
+FROM docker.io/redhat/ubi10
+COPY yumrepogen_setup.sh /root/yumrepogen_setup.sh
+RUN \
+  chmod a+x /root/yumrepogen_setup.sh && /root/yumrepogen_setup.sh && \
+  cat /etc/yum.repos.d/* && \
+  dnf install -y keylime-verifier which && \
+  dnf clean all
+
+EXPOSE 8881
+
+CMD ["keylime_verifier"]

--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -2588,6 +2588,7 @@ limeconPrepareImage() {
 
     local DOCKER_FILE=$1
     local TAG=$2
+    local SCRIPT
 
     if [ -z "${DOCKER_FILE}" ] || [ -z "${TAG}" ]; then
         echo "Docker file or build tag was not specified!"
@@ -2611,10 +2612,10 @@ limeconPrepareImage() {
         ARGS="--volume /var/tmp/keylime_sources:/mnt/keylime_sources:z"
     fi
 
-    # copy lime_con_install_upstream.sh to the current dir just in case it would be needed
-    if grep -q 'lime_con_install_upstream.sh' ${DOCKER_FILE}; then
-        cp -n ${limeLibraryDir}/lime_con_install_upstream.sh .
-    fi
+    # copy various helper scripts to the current dir just in case it would be needed
+    for SCRIPT in lime_con_install_upstream.sh yumrepogen_setup.sh; do
+        [ -f "${limeLibraryDir}/$SCRIPT" ] && cp -n ${limeLibraryDir}/$SCRIPT .
+    done
 
     CMDLINE="podman build $ARGS -t=$TAG --file=$DOCKER_FILE ."
     echo -e "\nRunning podman:\n$CMDLINE"

--- a/Library/test-helpers/yumrepogen_setup.sh
+++ b/Library/test-helpers/yumrepogen_setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pushd /root
+ARCH=$(arch)
+curl -kLo yumrepogen "https://gitlab.cee.redhat.com/api/v4/projects/72924/jobs/artifacts/main/raw/yumrepogen-$ARCH?job=compile"
+curl -kLo rhel.repo.tmpl 'https://gitlab.cee.redhat.com/testing-farm/yumrepogen/-/raw/main/rhel.repo.tmpl?inline=false'
+chmod a+x yumrepogen
+./yumrepogen -insecure -arch=$ARCH -compose-id=$(curl -kLs 'http://storage.tft.osci.redhat.com/composes-production.json' | grep -E -o "RHEL-$( rpm -q --qf '%{VERSION}' redhat-release )[^\"]+" | head -1) -outfile /etc/yum.repos.d/yumrepogen.repo
+yum config-manager --set-enabled rhel-BaseOS --set-enabled rhel-AppStream


### PR DESCRIPTION
## Summary by Sourcery

Add UBI-based Dockerfiles and supporting tooling for generating RHEL yum repositories in test images.

New Features:
- Introduce UBI-based Dockerfiles for agent, registrar, systemd, tenant, and verifier test containers.
- Add a yumrepogen setup script to dynamically generate RHEL yum repository configuration inside test environments.

Enhancements:
- Standardize RHEL repository enablement in test containers via a shared setup helper.