### PR TITLE
Fix relevancy conditions for faked_measured_boot_log

### DIFF
--- a/functional/durable-attestion-sanity-on-localhost/main.fmf
+++ b/functional/durable-attestion-sanity-on-localhost/main.fmf
@@ -33,13 +33,8 @@ adjust:
   - when: distro == rhel-8 or distro = centos-stream-8
     enabled: false
     because: RHEL-8 has old tpm2-tools
-  - when: agent == rust and faked_measured_boot_log is not defined
+  - when: faked_measured_boot_log is not defined or faked_measured_boot_log != yes
     enabled: false
-    because: For Rust agent we are not able to fake measuredboot log during 
-        runtime
-  - when: agent == rust and faked_measured_boot_log != yes
-    enabled: false
-    because: For Rust agent we are not able to fake measuredboot log during 
-        runtime
+    because: For Rust agent we are not able to fake measuredboot log during runtime
 extra-nitrate: TC#0615273
 id: ca228e8b-ee98-40d9-ac66-aba595873f90

--- a/functional/measured-boot-swtpm-sanity/main.fmf
+++ b/functional/measured-boot-swtpm-sanity/main.fmf
@@ -39,14 +39,9 @@ adjust:
   - when: distro == rhel-8 or distro = centos-stream-8
     enabled: false
     because: RHEL-8 has old tpm2-tools
-  - when: agent == rust and faked_measured_boot_log is not defined
+  - when: faked_measured_boot_log is not defined or faked_measured_boot_log != yes
     enabled: false
-    because: For Rust agent we are not able to fake measuredboot log during 
-        runtime
-  - when: agent == rust and faked_measured_boot_log != yes
-    enabled: false
-    because: For Rust agent we are not able to fake measuredboot log during 
-        runtime
+    because: For Rust agent we are not able to fake measuredboot log during runtime
 /push:
     environment:
         AGENT_SERVICE: PushAgent


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update test metadata to correct relevancy conditions for durable attestation localhost and measured boot SWTPM sanity scenarios.