### PR TITLE
use larger portion of the log for check

### DIFF
--- a/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
+++ b/compatibility/basic-attestation-on-localhost-with-allowlist-excludelist/test.sh
@@ -64,7 +64,7 @@ rlJournalStart
         rlRun "echo -e '#!/bin/bash\necho boom' > $TESTDIR/bad-script.sh && chmod a+x $TESTDIR/bad-script.sh"
         rlRun "$TESTDIR/bad-script.sh"
         rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
-        rlRun "rlWaitForCmd 'tail \$(limeVerifierLogfile) | grep -q \"Agent $AGENT_ID failed\"' -m 10 -d 1 -t 10"
+        rlRun "rlWaitForCmd 'tail -n 30 \$(limeVerifierLogfile) | grep -q \"Agent $AGENT_ID failed\"' -m 10 -d 1 -t 10"
         rlAssertGrep "WARNING - File not found in allowlist: $TESTDIR/bad-script.sh" $(limeVerifierLogfile)
         rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
     rlPhaseEnd


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Expand the tailed verifier log lines in the basic attestation allowlist/excludelist test to search a larger window for agent failure output.