### PR TITLE
run unittests locally [rhel-10-main]

### DIFF
--- a/plans/distribution-c10s-keylime-tests-github-ci.fmf
+++ b/plans/distribution-c10s-keylime-tests-github-ci.fmf
@@ -29,6 +29,7 @@ discover:
    - "^/sanity/.*"
    - "^/regression/.*"
    - "^/compatibility/.*"
+   - "^/upstream/run_tests_for_installed_keylime"
    - /update/basic-attestation-on-localhost/all
 
 execute:

--- a/plans/upstream-keylime-all-tests.fmf
+++ b/plans/upstream-keylime-all-tests.fmf
@@ -27,6 +27,7 @@ discover:
    - /update/basic-attestation-on-localhost/all
    # run upstream test suite
    - /upstream/run_keylime_tests
+   - /upstream/run_tests_for_installed_keylime
    - /setup/generate_coverage_report
    - /setup/generate_upstream_rust_keylime_code_coverage
 

--- a/setup/install_upstream_keylime/test.sh
+++ b/setup/install_upstream_keylime/test.sh
@@ -81,7 +81,9 @@ _EOF'
 
         # install scripts to /usr/share/keylime
         rlRun "mkdir -p /usr/share/keylime"
-        rlRun "cp -r scripts /usr/share/keylime/"
+        for RES in scripts templates tpm_cert_store; do
+            rlRun "cp -r $RES /usr/share/keylime/"
+        done
 
         # install manpages - convert from .rst to man format
         rlRun "yum install -y python3-docutils python3-pip" 0 "Install rst2man tool and pip"

--- a/upstream/run_tests_for_installed_keylime/main.fmf
+++ b/upstream/run_tests_for_installed_keylime/main.fmf
@@ -1,0 +1,25 @@
+summary: Run unit tests for installed keylime
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - upstream
+require:
+  - yum
+  - openssl
+  - python3-pip
+  - rpm-build
+  - rpm-sign
+  - createrepo_c
+  - python-devel
+  - selinux-policy-devel
+recommend:
+  - keylime
+duration: 15m
+enabled: true
+
+adjust:
+ - when: distro == rhel-8 or distro == rhel-9
+   enabled: false

--- a/upstream/run_tests_for_installed_keylime/test.sh
+++ b/upstream/run_tests_for_installed_keylime/test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+export KEYLIME_SRC
+export KEYLIME_TEST_MODE
+export KEYLIME_TEST_SRC
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+        rlRun "TmpDir=\$( mktemp -d )"
+        pushd "$TmpDir" || rlDie "Cannot enter temporary directory $TmpDir"
+	# prepare variables
+	if [ -d /var/tmp/keylime_sources ]; then
+            # keylime installed from sources in /var/tmp/keylime_sources
+            KEYLIME_SRC=$( ls -d /usr/local/lib/python3.14/site-packages/keylime )
+	    KEYLIME_DIR=/var/tmp/keylime_sources
+	else
+            # keylime installed from RPM
+            rlRun "dnf download --source keylime"
+            rlRun "rpm -i keylime*.src.rpm"
+	    rlRun "rpmbuild -bp --nodeps ~/rpmbuild/SPECS/keylime.spec"
+	    rlRun "rm -rf ~/rpmbuild/BUILD/keylime-*-SPECPARTS"
+            KEYLIME_SRC=$( ls -d /usr/lib/*/site-packages/keylime )
+	    KEYLIME_DIR="~/rpmbuild/BUILD/keylime*"
+	fi
+	[ -n "$KEYLIME_SRC" ] && [ -d "$KEYLIME_SRC" ] || rlDie "Cannot locate installed keylime files"
+	KEYLIME_TEST_MODE=installed
+	KEYLIME_TEST_SRC=$TmpDir/test
+	# copy and link various test resources
+	rlRun "cp -r ${KEYLIME_DIR}/{test,test-data} ."
+	# prepare symlink to keylime sources
+	rlRun "ln -s $KEYLIME_SRC keylime"
+	for RES in scripts templates tpm_cert_store; do
+            rlRun "ln -s /usr/share/keylime/$RES $RES"
+        done
+	# replace run_tests.sh script with the upstream version
+	rlFileBackup "$KEYLIME_TEST_SRC/run_tests.sh"
+	rlRun "curl -s https://raw.githubusercontent.com/keylime/keylime/refs/heads/master/test/run_tests.sh > $KEYLIME_TEST_SRC/run_tests.sh"
+	# install green
+        rlRun "pip3 install green"
+        # backup keylime
+        rlRun "rlFileBackup --missing-ok /var/lib/keylime"
+        limeBackupConfig
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run unit tests"
+        rlRun "$KEYLIME_TEST_SRC/run_tests.sh"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        limeClearData
+        limeRestoreConfig
+        rlFileRestore
+        rlRun "rm -rf $TmpDir"
+    rlPhaseEnd
+
+rlJournalEnd


### PR DESCRIPTION
## Summary by Sourcery

Add support for running upstream Keylime unit tests against an installed Keylime package and ensure required runtime resources are available under /usr/share/keylime.

New Features:
- Introduce a beakerlib-based test that runs upstream Keylime unit tests against an installed Keylime instance using the upstream test runner.

Enhancements:
- Ensure Keylime scripts, templates, and TPM certificate store are installed under /usr/share/keylime for use by tests and runtime tooling.

Tests:
- Set up a new test workflow that prepares an environment from either source or RPM-installed Keylime and executes the upstream run_tests.sh suite.
- Add FMF metadata for the new installed-Keylime unit-test plan.