### PR TITLE
Expect TIMEOUT instead of FAIL for stopped agent

### DIFF
--- a/functional/agent-resilience-and-reattestation/test.sh
+++ b/functional/agent-resilience-and-reattestation/test.sh
@@ -175,14 +175,22 @@ function check_time_diffs() {
         rlRun -s "keylime_tenant -c cvlist"
     rlPhaseEnd
 
-    rlPhaseStartTest "Stop agent so it stops sending quotes - should fail attestation"
+    if [ "${AGENT_SERVICE}" == "PushAgent" ]; then
+        EXPECTED_STATUS="TIMEOUT"
+        EXPECTED_LABEL="timeout"
+    else
+        EXPECTED_STATUS="(Failed|Invalid Quote)"
+        EXPECTED_LABEL="fail"
+    fi
+
+    rlPhaseStartTest "Stop agent so it stops sending quotes - should ${EXPECTED_LABEL} attestation"
         rlLogInfo "Stopping agent"
         rlRun "limeStop${AGENT_SERVICE}"
         # verify the agent is not attested
         if [ "${AGENT_SERVICE}" == "PushAgent" ]; then
-            rlRun "limeTIMEOUT=$(( ${ATTESTATION_INTERVAL}*6 )) limeWaitForAgentStatus --field attestation_status '$AGENT_ID' 'FAIL'" 0 "Agent should fail attestation"
+            rlRun "limeTIMEOUT=$(( ATTESTATION_INTERVAL*6 )) limeWaitForAgentStatus --field attestation_status '$AGENT_ID' '${EXPECTED_STATUS}'" 0 "Agent should ${EXPECTED_LABEL} attestation"
         else
-            rlRun "limeTIMEOUT=$(( ${ATTESTATION_INTERVAL}*6 )) limeWaitForAgentStatus '$AGENT_ID' '(Failed|Invalid Quote)'" 0 "Agent should fail attestation"
+            rlRun "limeTIMEOUT=$(( ATTESTATION_INTERVAL*6 )) limeWaitForAgentStatus '$AGENT_ID' '${EXPECTED_STATUS}'" 0 "Agent should ${EXPECTED_LABEL} attestation"
         fi
         rlRun -s "keylime_tenant -c cvlist"
     rlPhaseEnd

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -5,8 +5,8 @@ context:
 
 # modify defaults below to point upstream keylime URL to a different repo and branch
 environment:
-  KEYLIME_UPSTREAM_URL: "https://github.com/keylime/keylime.git"
-  KEYLIME_UPSTREAM_BRANCH: "master"
+  KEYLIME_UPSTREAM_URL: "https://github.com/sarroutbi/keylime.git"
+  KEYLIME_UPSTREAM_BRANCH: "fix-push-mode-timeouts-202604192044"
   # variables below impact only plans that use /setup/install_upstream_rust_keylime
   # task, not plans using /setup/install_rust_keylime_from_copr
   RUST_KEYLIME_UPSTREAM_URL: "https://github.com/keylime/rust-keylime.git"


### PR DESCRIPTION
Resolves: #1059

Upstream keylime commit 982a86b changed process_get_status() to return "TIMEOUT" instead of "FAIL" when a PUSH mode agent stops sending quotes. Update the agent-resilience-and-reattestation test to match the new upstream behavior.

## Summary by Sourcery

Tests:
- Adjust the agent-resilience-and-reattestation test to expect a TIMEOUT status instead of FAIL for PushAgent when quotes stop, while unifying status/label handling for different agent types.