### PR TITLE
backport multi-host push attestation test

### DIFF
--- a/Multihost/basic-attestation/main.fmf
+++ b/Multihost/basic-attestation/main.fmf
@@ -23,6 +23,7 @@ require:
   - wget
 recommend:
   - keylime
+  - keylime-agent-rust
   - python3-tomli
   - python3-toml
 duration: 30m

--- a/Multihost/basic-push-attestation/main.fmf
+++ b/Multihost/basic-push-attestation/main.fmf
@@ -1,0 +1,27 @@
+summary: Tests basic keylime push model attestation scenario on multiple hosts
+description: |
+    Running services on different systems - verifier, registrar, agent1+tenant, agent2.
+    Uses custom build certificates.
+    Starts verifier, registrar, agent, agent2.
+    Registers both agents.
+    Verifies that systems passed attestation.
+    Does changes on a system with agent1 and verifies that system has failed attestation.
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - multihost
+  - CI-Tier-1-Multi
+require:
+  - library(openssl/certgen)
+  - yum
+  - bind-utils
+  - wget
+recommend:
+  - keylime
+  - keylime-agent-rust-push
+duration: 30m
+enabled: true
+id: 7e303923-9e34-405a-b78a-eb53c07af4bd

--- a/Multihost/basic-push-attestation/test.sh
+++ b/Multihost/basic-push-attestation/test.sh
@@ -2,13 +2,11 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   runtest.sh of /CoreOS/keylime/Multihost/basic-attestation
-#   Description: tests basic keylime attestation scenario using multiple hosts
 #   Author: Karel Srot <ksrot@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   Copyright (c) 2021 Red Hat, Inc.
+#   Copyright (c) 2026 Red Hat, Inc.
 #
 #   This program is free software: you can redistribute it and/or
 #   modify it under the terms of the GNU General Public License as
@@ -25,8 +23,6 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Include Beaker environment
-#. /usr/bin/rhts-environment.sh || exit 1
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 # when manually troubleshooting multihost test in Restraint environment
@@ -34,18 +30,10 @@
 # to make user that sync events have unique names and there are not
 # collisions with former test runs
 
-# set REVOCATION_NOTIFIER=zeromq to use the zeromq notifier
-[ -n "$REVOCATION_NOTIFIER" ] || REVOCATION_NOTIFIER=agent
-if [ "${USE_ALLOWLIST_FOR_AGENT2}" == "true" -o "${USE_ALLOWLIST_FOR_AGENT2}" == "yes" ]; then
-    USE_ALLOWLIST_FOR_AGENT2=true
-else
-    USE_ALLOWLIST_FOR_AGENT2=false
-fi
-
-
 # load helper functions
-. ../multihost-roles-functions.sh
+source ../multihost-roles-functions.sh
 
+ATTESTATION_INTERVAL=20
 
 Verifier() {
     rlPhaseStartSetup "Verifier setup"
@@ -60,16 +48,12 @@ Verifier() {
         rlRun "x509KeyGen verifier-client" 0 "Preparing RSA verifier-client certificate"
         rlRun "x509KeyGen registrar" 0 "Preparing RSA registrar certificate"
         rlRun "x509KeyGen tenant" 0 "Preparing RSA tenant certificate"
-        rlRun "x509KeyGen agent" 0 "Preparing RSA tenant certificate"
-        [ -n "${AGENT2}" ] && rlRun "x509KeyGen agent2" 0 "Preparing RSA tenant certificate"
         rlRun "x509SelfSign ca" 0 "Selfsigning CA certificate"
         rlRun "x509CertSign --CA ca --DN 'CN = $VERIFIER_IP' -t webserver --subjectAltName 'IP = ${VERIFIER_IP}' verifier" 0 "Signing verifier certificate with our CA certificate"
         rlRun "x509CertSign --CA ca --DN 'CN = $VERIFIER_IP' -t webclient --subjectAltName 'IP = ${VERIFIER_IP}' verifier-client" 0 "Signing verifier-client certificate with our CA certificate"
         rlRun "x509CertSign --CA ca --DN 'CN = $REGISTRAR' -t webserver --subjectAltName 'IP = ${REGISTRAR_IP}' registrar" 0 "Signing registrar certificate with our CA certificate"
         # remember, we are running tenant on agent server
         rlRun "x509CertSign --CA ca --DN 'CN = ${AGENT}' -t webclient --subjectAltName 'IP = ${AGENT_IP}' tenant" 0 "Signing tenant certificate with our CA"
-        rlRun "x509SelfSign --DN 'CN = ${AGENT}' -t webserver agent" 0 "Self-signing agent certificate"
-        [ -n "${AGENT2}" ] && rlRun "x509SelfSign --DN 'CN = ${AGENT2}' -t webserver agent2" 0 "Self-signing agent2 certificate"
 
         # copy verifier certificates to proper location
         CERTDIR=/var/lib/keylime/certs
@@ -88,10 +72,6 @@ Verifier() {
         rlRun "cp $(x509Key registrar) http/registrar-key.pem"
         rlRun "cp $(x509Cert tenant) http/tenant-cert.pem"
         rlRun "cp $(x509Key tenant) http/tenant-key.pem"
-        rlRun "cp $(x509Cert agent) http/agent-cert.pem"
-        rlRun "cp $(x509Key agent) http/agent-key.pem"
-        [ -n "${AGENT2}" ] && rlRun "cp $(x509Cert agent2) http/agent2-cert.pem"
-        [ -n "${AGENT2}" ] && rlRun "cp $(x509Key agent2) http/agent2-key.pem"
         rlRun "pushd http"
         rlRun "python3 -m http.server 8000 &"
         HTTP_PID=$!
@@ -109,15 +89,12 @@ Verifier() {
         rlRun "limeUpdateConf verifier client_key verifier-client-key.pem"
         rlRun "limeUpdateConf revocations zmq_ip ${VERIFIER_IP}"
         rlRun "limeUpdateConf verifier client_key ${CERTDIR}/verifier-client-key.pem"
-        rlRun "limeUpdateConf revocations enabled_revocation_notifications '[\"${REVOCATION_NOTIFIER}\"]'"
-        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
-        fi
-
-	# FIXME: expose verifier.conf so that tenant can download it
-	# this is a keylime issue which we need to workaroun ATM
-	# https://github.com/keylime/keylime/issues/1541#issuecomment-2221267087
-	rlIsRHELLike 9 || rlRun "cp /etc/keylime/verifier.conf http"
+        rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
+        # Set the verifier to run in PUSH mode
+        rlRun "limeUpdateConf verifier mode 'push'"
+        rlRun "limeUpdateConf verifier challenge_lifetime 1800"
+	rlRun "limeUpdateConf verifier session_lifetime 180"
+        rlRun "limeUpdateConf verifier quote_interval ${ATTESTATION_INTERVAL}"
 
         # Delete other components configuration files
         for comp in agent registrar tenant; do
@@ -129,13 +106,6 @@ Verifier() {
         rlRun "limeWaitForVerifier"
         rlRun "sync-set VERIFIER_SETUP_DONE"
         rlRun "sync-block AGENT_ALL_TESTS_DONE ${AGENT_IP}" 0 "Waiting for the Agent to finish the test"
-    rlPhaseEnd
-
-    rlPhaseStartTest "Verifier test"
-        # check that the AGENT failed verification
-        rlAssertGrep "WARNING - File not found in allowlist: .*/keylime-bad-script.sh" $(limeVerifierLogfile) -E
-        AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
-        rlAssertGrep "WARNING - Agent $AGENT_ID failed, stopping polling" $(limeVerifierLogfile)
     rlPhaseEnd
 
     rlPhaseStartCleanup "Verifier cleanup"
@@ -199,17 +169,11 @@ Agent() {
 
         # download certificates from the verifier
         CERTDIR=/var/lib/keylime/certs
-        SECUREDIR=/var/lib/keylime/secure
         rlRun "mkdir -p ${CERTDIR}"
-        rlRun "mkdir -p $SECUREDIR"
-        for F in cacert.pem tenant-cert.pem tenant-key.pem agent-key.pem agent-cert.pem; do
+        for F in cacert.pem tenant-cert.pem tenant-key.pem; do
             rlRun "wget -O ${CERTDIR}/$F 'http://$VERIFIER:8000/$F'"
         done
         id keylime && rlRun "chown -R keylime:keylime ${CERTDIR}"
-        # agent mTLS certs are supposed to be in the SECUREDIR
-        rlRun "mount -t tmpfs -o size=2m,mode=0700 tmpfs ${SECUREDIR}"
-        rlRun "cp ${CERTDIR}/{agent-key.pem,agent-cert.pem} ${SECUREDIR}"
-        id keylime && rlRun "chown -R keylime:keylime ${SECUREDIR}"
 
         # configure tenant
         rlRun "limeUpdateConf tenant registrar_ip ${REGISTRAR_IP}"
@@ -225,42 +189,23 @@ Agent() {
         rlRun "limeUpdateConf tenant client_key tenant-key.pem"
         rlRun "limeUpdateConf tenant client_key ${CERTDIR}/tenant-key.pem"
 
-        # configure agent
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf agent tls_dir ${CERTDIR}"
-            rlRun "limeUpdateConf agent ip ${AGENT_IP}"
-            rlRun "limeUpdateConf agent contact_ip ${AGENT_IP}"
-            rlRun "limeUpdateConf agent registrar_ip ${REGISTRAR_IP}"
-            rlRun "limeUpdateConf agent trusted_client_ca '[\"cacert.pem\"]'"
-            rlRun "limeUpdateConf agent server_key agent-key.pem"
-            rlRun "limeUpdateConf agent server_cert agent-cert.pem"
-            rlRun "limeUpdateConf agent revocation_notification_ip ${VERIFIER_IP}"
-        else
-            # tls_dir not supported by the Rust agent, using /var/lib/keylime by default
-            #rlRun "limeUpdateConf agent tls_dir '\"${CERTDIR}\"'"
-            rlRun "limeUpdateConf agent ip '\"${AGENT_IP}\"'"
-            rlRun "limeUpdateConf agent contact_ip '\"${AGENT_IP}\"'"
-            rlRun "limeUpdateConf agent registrar_ip '\"${REGISTRAR_IP}\"'"
-            rlRun "limeUpdateConf agent trusted_client_ca '\"${CERTDIR}/cacert.pem\"'"
-            rlRun "limeUpdateConf agent server_key '\"${CERTDIR}/agent-key.pem\"'"
-            rlRun "limeUpdateConf agent server_cert '\"${CERTDIR}/agent-cert.pem\"'"
-            rlRun "limeUpdateConf agent revocation_notification_ip '\"${VERIFIER_IP}\"'"
-        fi
-
-        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            rlRun "limeUpdateConf agent enable_revocation_notifications False"
-        fi
+        # tls_dir not supported by the Rust agent, using /var/lib/keylime by default
+        #rlRun "limeUpdateConf agent ip '\"${AGENT_IP}\"'"
+        #rlRun "limeUpdateConf agent contact_ip '\"${AGENT_IP}\"'"
+        rlRun "limeUpdateConf agent verifier_url '\"https://${VERIFIER_IP}:8881\"'"
+        rlRun "limeUpdateConf agent verifier_tls_ca_cert '\"${CERTDIR}/cacert.pem\"'"
+        rlRun "limeUpdateConf agent registrar_ip '\"${REGISTRAR_IP}\"'"
+        rlRun "limeUpdateConf agent registrar_tls_enabled true"
+        rlRun "limeUpdateConf agent registrar_tls_ca_cert '\"${CERTDIR}/cacert.pem\"'"
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
+        rlRun "limeUpdateConf agent attestation_interval_seconds ${ATTESTATION_INTERVAL}"
+        rlRun "limeUpdateConf agent enable_authentication true"
+        #rlRun "limeUpdateConf agent tls_accept_invalid_certs true"
 
         # Delete other components configuration files
         for comp in verifier registrar; do
             rlRun "rm -rf /etc/keylime/$comp.conf*"
         done
-
-
-	# FIXME: expose verifier.conf so that tenant can download it
-	# this is a keylime issue which we need to workaroun ATM
-	# https://github.com/keylime/keylime/issues/1541#issuecomment-2221267087
-        rlIsRHELLike 9 || rlRun "wget -O /etc/keylime/verifier.conf 'http://$VERIFIER:8000/verifier.conf'"
 
         # if TPM emulator is present
         if limeTPMEmulated; then
@@ -274,7 +219,7 @@ Agent() {
         fi
         sleep 5
 
-        rlRun "limeStartAgent"
+        rlRun "limeStartPushAgent"
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         # create allowlist and excludelist
         limeCreateTestPolicy
@@ -285,53 +230,29 @@ if [ -n "${AGENT2}" ]; then
         # wait for Agent2 setup is done
         rlRun "sync-block AGENT2_SETUP_DONE ${AGENT2}" 0 "Waiting for the Agent2 setup to finish"
 
-        # first register AGENT2 and confirm it has passed validation
+        # first activate AGENT2 and confirm it has passed validation
         AGENT2_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c33333"
-        # download Agent2 list
-        if ${USE_ALLOWLIST_FOR_AGENT2}; then
-            rlRun "wget -O allowlist2.txt 'http://${AGENT2_IP}:8000/allowlist.txt'"
-            rlRun "wget -O excludelist2.txt 'http://${AGENT2_IP}:8000/excludelist.txt'"
-            POLICYPARAMS="--allowlist allowlist2.txt --exclude excludelist2.txt"
-        else
-            rlRun "wget -O policy2.json 'http://${AGENT2_IP}:8000/policy.json'"
-            rlRun "cat policy2.json"
-            POLICYPARAMS="--runtime-policy policy2.json"
-        fi
-        # register
-        rlRun "cat > script.expect <<_EOF
-set timeout 20
-spawn keylime_tenant -v ${VERIFIER_IP} -t ${AGENT2_IP} -u ${AGENT2_ID} ${POLICYPARAMS} --include payload-${REVOCATION_SCRIPT_TYPE} --cert default -c add
-expect \"Please enter the password to decrypt your keystore:\"
-send \"keylime\n\"
-expect eof
-_EOF"
-        rlRun -s "expect script.expect"
+        # download Agent2 policy
+        rlRun "wget -O policy2.json 'http://${AGENT2_IP}:8000/policy.json'"
+        rlRun "cat policy2.json"
+        # activate
+        rlRun -s "keylime_tenant -v ${VERIFIER_IP} -t ${AGENT2_IP} -u ${AGENT2_ID} --runtime-policy policy2.json -c add --push-model"
         rlAssertNotGrep "ERROR" $rlRun_LOG -i
-        rlRun "limeWaitForAgentStatus ${AGENT2_ID} 'Get Quote'"
+	rlRun "limeWaitForAgentStatus --field attestation_status '${AGENT2_ID}' 'PASS'"
         rlRun -s "keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'${AGENT2_ID}'" $rlRun_LOG -E
-        rlRun "limeWaitForAgentStatus ${AGENT2_ID} 'Get Quote'"
     rlPhaseEnd
 fi
 
     rlPhaseStartTest "keylime attestation test: Add Agent"
-        # register AGENT and confirm it has passed validation
+        # activate AGENT and confirm it has passed validation
         AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
         rlRun "cat policy.json"
-        rlRun "cat > script.expect <<_EOF
-set timeout 20
-spawn keylime_tenant -v ${VERIFIER_IP} -t ${AGENT_IP} -u ${AGENT_ID} --runtime-policy policy.json --include payload-${REVOCATION_SCRIPT_TYPE} --cert default -c add
-expect \"Please enter the password to decrypt your keystore:\"
-send \"keylime\n\"
-expect eof
-_EOF"
-        rlRun -s "expect script.expect"
+        rlRun -s "keylime_tenant -v ${VERIFIER_IP} -t ${AGENT_IP} -u ${AGENT_ID} --runtime-policy policy.json --push-model -c add"
         rlAssertNotGrep "ERROR" $rlRun_LOG -i
-        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
+	rlRun "limeWaitForAgentStatus --field attestation_status '${AGENT_ID}' 'PASS'"
         rlRun -s "keylime_tenant -c cvlist"
         rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
-        rlWaitForFile /var/tmp/test_payload_file -t 30 -d 1  # we may need to wait for it to appear a bit
-        rlAssertExists /var/tmp/test_payload_file
     rlPhaseEnd
 
     rlPhaseStartTest "Agent attestation test: Fail keylime agent"
@@ -340,26 +261,18 @@ _EOF"
         limeExtendNextExcludelist $TESTDIR
         rlRun "echo -e '#!/bin/bash\necho boom' > $TESTDIR/keylime-bad-script.sh && chmod a+x $TESTDIR/keylime-bad-script.sh"
         rlRun "$TESTDIR/keylime-bad-script.sh"
-        rlRun "limeWaitForAgentStatus $AGENT_ID '(Failed|Invalid Quote)'"
-        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            # give the revocation notifier a bit more time to contact the agent
-            rlRun "rlWaitForCmd 'tail \$(limeAgentLogfile) | grep -q \"A node in the network has been compromised: ${AGENT_IP}\"' -m 20 -d 1 -t 20"
-            rlRun "tail $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
-            rlRun "tail $(limeAgentLogfile) | grep 'A node in the network has been compromised: ${AGENT_IP}'"
-            rlAssertNotExists /var/tmp/test_payload_file
-        fi
+	rlRun "limeWaitForAgentStatus --field attestation_status '${AGENT_ID}' 'FAIL'"
     rlPhaseEnd
 
     rlPhaseStartCleanup "Agent cleanup"
         rlRun "sync-set AGENT_ALL_TESTS_DONE"
-        rlRun "limeStopAgent"
+        rlRun "limeStopPushAgent"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"
             rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
-        rlRun "rm -f /var/tmp/test_payload_file"
     rlPhaseEnd
 }
 
@@ -373,46 +286,24 @@ Agent2() {
 
         # download certificates from the verifier
         CERTDIR=/var/lib/keylime/certs
-        SECUREDIR=/var/lib/keylime/secure
         rlRun "mkdir -p ${CERTDIR}"
-        rlRun "mkdir -p $SECUREDIR"
-        for F in cacert.pem agent2-key.pem agent2-cert.pem; do
+        for F in cacert.pem; do
             rlRun "wget -O ${CERTDIR}/$F 'http://$VERIFIER:8000/$F'"
         done
         id keylime && rlRun "chown -R keylime:keylime ${CERTDIR}"
-        # agent mTLS certs are supposed to be in the SECUREDIR
-        rlRun "mount -t tmpfs -o size=2m,mode=0700 tmpfs ${SECUREDIR}"
-        rlRun "cp ${CERTDIR}/{agent2-key.pem,agent2-cert.pem} ${SECUREDIR}"
-        id keylime && rlRun "chown -R keylime:keylime ${SECUREDIR}"
 
-        # configure agent
-        if limeIsPythonAgent; then
-            rlRun "limeUpdateConf agent uuid ${AGENT2_ID}"
-            rlRun "limeUpdateConf agent tls_dir ${CERTDIR}"
-            rlRun "limeUpdateConf agent ip ${AGENT2_IP}"
-            rlRun "limeUpdateConf agent contact_ip ${AGENT2_IP}"
-            rlRun "limeUpdateConf agent registrar_ip ${REGISTRAR_IP}"
-            rlRun "limeUpdateConf agent trusted_client_ca '[\"cacert.pem\"]'"
-            rlRun "limeUpdateConf agent server_key agent2-key.pem"
-            rlRun "limeUpdateConf agent server_cert agent2-cert.pem"
-            rlRun "limeUpdateConf agent revocation_notification_ip ${VERIFIER_IP}"
-
-        else
-            rlRun "limeUpdateConf agent uuid '\"${AGENT2_ID}\"'"
-            # tls_dir is not supported in the rust agent
-            #rlRun "limeUpdateConf agent tls_dir '\"${CERTDIR}\"'"
-            rlRun "limeUpdateConf agent ip '\"${AGENT2_IP}\"'"
-            rlRun "limeUpdateConf agent contact_ip '\"${AGENT2_IP}\"'"
-            rlRun "limeUpdateConf agent registrar_ip '\"${REGISTRAR_IP}\"'"
-            rlRun "limeUpdateConf agent trusted_client_ca '\"${CERTDIR}/cacert.pem\"'"
-            rlRun "limeUpdateConf agent server_key '\"${CERTDIR}/agent2-key.pem\"'"
-            rlRun "limeUpdateConf agent server_cert '\"${CERTDIR}/agent2-cert.pem\"'"
-            rlRun "limeUpdateConf agent revocation_notification_ip '\"${VERIFIER_IP}\"'"
-        fi
-
-        if [ -n "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            rlRun "limeUpdateConf agent enable_revocation_notifications False"
-        fi
+        rlRun "limeUpdateConf agent uuid '\"${AGENT2_ID}\"'"
+        #rlRun "limeUpdateConf agent ip '\"${AGENT2_IP}\"'"
+        #rlRun "limeUpdateConf agent contact_ip '\"${AGENT2_IP}\"'"
+        rlRun "limeUpdateConf agent verifier_url '\"https://${VERIFIER_IP}:8881\"'"
+        rlRun "limeUpdateConf agent verifier_tls_ca_cert '\"${CERTDIR}/cacert.pem\"'"
+        rlRun "limeUpdateConf agent registrar_ip '\"${REGISTRAR_IP}\"'"
+        rlRun "limeUpdateConf agent registrar_tls_enabled true"
+        rlRun "limeUpdateConf agent registrar_tls_ca_cert '\"${CERTDIR}/cacert.pem\"'"
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
+        rlRun "limeUpdateConf agent attestation_interval_seconds ${ATTESTATION_INTERVAL}"
+        rlRun "limeUpdateConf agent enable_authentication true"
+        #rlRun "limeUpdateConf agent tls_accept_invalid_certs true"
 
         # Delete other components configuration files
         for comp in verifier tenant registrar; do
@@ -431,7 +322,7 @@ Agent2() {
         fi
         sleep 5
 
-        rlRun "limeStartAgent"
+        rlRun "limeStartPushAgent"
         # cannot use limeWaitForAgentRegistration as we do not have tenant configured
         # so let's just wait for 20 seconds
         rlRun "sleep 20"
@@ -446,36 +337,22 @@ Agent2() {
         HTTP_PID=$!
         rlRun "popd"
 
-        # find the end of my log
-        LOG_END=$( cat $(limeAgentLogfile) | wc -l )
         rlRun "sync-set AGENT2_SETUP_DONE"
-    rlPhaseEnd
-
-    rlPhaseStartTest "Agent2 test: Verify Agent failed validation + revocation"
         # waif for Agent to finish his tests (including failed validation)
         rlRun "sync-block AGENT_ALL_TESTS_DONE ${AGENT_IP}"
-
-        if [ -z "$KEYLIME_TEST_DISABLE_REVOCATION" ]; then
-            # installed payload should not have been deleted for Agent2
-            rlAssertExists /var/tmp/test_payload_file
-            rlRun "sed -n '${LOG_END},\$ p' $(limeAgentLogfile) | grep 'Executing revocation action local_action_modify_payload'"
-            rlRun "sed -n '${LOG_END},\$ p' $(limeAgentLogfile) | grep 'A node in the network has been compromised: ${AGENT_IP}'"
-        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup "Agent2 cleanup"
         rlRun "kill $HTTP_PID"
-        rlRun "rm -f /var/tmp/test_payload_file"
-        limeStopAgent
+        rlRun "limeStopPushAgent"
         if limeTPMEmulated; then
-            limeStopIMAEmulator
-            limeStopTPMEmulator
+            rlRun "limeStopIMAEmulator"
+            rlRun "limeStopTPMEmulator"
             rlRun "limeCondStopAbrmd"
         fi
         limeSubmitCommonLogs
     rlPhaseEnd
 }
-
 
 
 ####################
@@ -488,6 +365,7 @@ rlJournalStart
     rlPhaseStartSetup
         # import keylime library
         rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlRun "export limeTIMEOUT=60"
         rlRun 'rlImport "./sync"' || rlDie "cannot import keylime-tests/sync library"
         rlRun 'rlImport "openssl/certgen"' || rlDie "cannot import openssl/certgen library"
 
@@ -507,10 +385,6 @@ rlJournalStart
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         # backup files
         limeBackupConfig
-        # load REVOCATION_SCRIPT_TYPE
-        REVOCATION_SCRIPT_TYPE=$( limeGetRevocationScriptType )
-        rlRun "cp -rf payload-${REVOCATION_SCRIPT_TYPE} $TmpDir"
-
         rlRun "pushd $TmpDir"
     rlPhaseEnd
 
@@ -531,7 +405,7 @@ rlJournalStart
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
-	rlRun "rm -r $CERTDIR" 0 "Removing $CERTDIR"
+        rlRun "rm -r $CERTDIR" 0 "Removing $CERTDIR"
 
         #################
         # common cleanup

--- a/Multihost/basic-push-attestation/test.sh
+++ b/Multihost/basic-push-attestation/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 #   Author: Karel Srot <ksrot@redhat.com>

--- a/Multihost/multihost-roles-functions.sh
+++ b/Multihost/multihost-roles-functions.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function assign_server_roles() {
+    if [ -n "${TMT_TOPOLOGY_BASH}" ] && [ -f ${TMT_TOPOLOGY_BASH} ]; then
+        # assign roles based on tmt topology data
+        cat ${TMT_TOPOLOGY_BASH}
+        . ${TMT_TOPOLOGY_BASH}
+
+        export VERIFIER=${TMT_GUESTS["verifier.hostname"]}
+        export REGISTRAR=${TMT_GUESTS["registrar.hostname"]}
+        export AGENT=${TMT_GUESTS["agent.hostname"]}
+        # AGENT2 may not be defined
+        if [ -n "${TMT_GUESTS["agent2.hostname"]}" ]; then
+            export AGENT2=${TMT_GUESTS["agent2.hostname"]}
+        fi
+        MY_IP="${TMT_GUEST['hostname']}"
+    elif [ -n "$SERVERS" ]; then
+        # assign roles using SERVERS and CLIENTS variables
+        export VERIFIER=$( echo "$SERVERS $CLIENTS" | awk '{ print $1 }')
+        export REGISTRAR=$( echo "$SERVERS $CLIENTS" | awk '{ print $2 }')
+        export AGENT=$( echo "$SERVERS $CLIENTS" | awk '{ print $3 }')
+        export AGENT2=$( echo "$SERVERS $CLIENTS" | awk '{ print $4 }')
+    fi
+
+    [ -z "$MY_IP" ] && MY_IP=$( hostname -I | awk '{ print $1 }' )
+    [ -n "$VERIFIER" ] && export VERIFIER_IP=$( get_IP $VERIFIER )
+    [ -n "$REGISTRAR" ] && export REGISTRAR_IP=$( get_IP $REGISTRAR )
+    [ -n "${AGENT}" ] && export AGENT_IP=$( get_IP ${AGENT} )
+    [ -n "${AGENT2}" ] && export AGENT2_IP=$( get_IP ${AGENT2} )
+}
+
+function get_IP() {
+    if echo $1 | grep -E -q '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
+        echo $1
+    else
+        host $1 | sed -n -e 's/.*has address //p' | head -n 1
+    fi
+}

--- a/plans/distribution-c10s-keylime-multihost.fmf
+++ b/plans/distribution-c10s-keylime-multihost.fmf
@@ -25,6 +25,7 @@ discover:
     test:
       #- /setup/enable_keylime_debug_messages
       - /Multihost/basic-attestation
+      - /Multihost/basic-push-attestation
 
 execute:
   how: tmt

--- a/plans/upstream-keylime-multihost.fmf
+++ b/plans/upstream-keylime-multihost.fmf
@@ -11,6 +11,8 @@ provision:
     role: registrar
   - name: agent
     role: agent
+  - name: agent2
+    role: agent2
 
 discover:
   - name: keylime_install
@@ -21,6 +23,7 @@ discover:
     how: fmf
     where:
       - agent
+      - agent2
     test:
       - /setup/configure_tpm_emulator
       - /setup/install_rust_keylime_from_copr
@@ -30,6 +33,7 @@ discover:
     test:
       #- /setup/enable_keylime_debug_messages
       - /Multihost/basic-attestation
+      - /Multihost/basic-push-attestation
 
 execute:
   how: tmt


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new multihost test for push-mode attestation and share multihost role-assignment helpers across tests.

New Features:
- Add a multihost basic push attestation test covering verifier, registrar, agent, and optional second agent in push mode.

Enhancements:
- Extract multihost role and IP assignment logic into a reusable helper script used by existing and new tests.
- Extend multihost attestation test cleanup to remove generated certificate directories.