### PR TITLE
Set registrar_tls_enabled = true

### DIFF
--- a/functional/push-attestation-on-localhost/test.sh
+++ b/functional/push-attestation-on-localhost/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
 	rlRun "limeUpdateConf verifier session_lifetime 180"
         rlRun "limeUpdateConf verifier quote_interval ${ATTESTATION_INTERVAL}"
         rlRun "limeUpdateConf agent attestation_interval_seconds ${ATTESTATION_INTERVAL}"
-
+        rlRun "limeUpdateConf agent registrar_tls_enabled true"
         rlRun "limeUpdateConf agent enable_authentication true"
 
         # Disable EK certificate verification on the tenant


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update the push-attestation-on-localhost functional test to set registrar_tls_enabled to true for the agent configuration.