### PR TITLE
Drop tests for features that are not implemented in RHEL-9.7.0

### DIFF
--- a/functional/agent-registration-with-non-default-tpm-algorithms/main.fmf
+++ b/functional/agent-registration-with-non-default-tpm-algorithms/main.fmf
@@ -24,6 +24,10 @@ adjust+:
   - when: swtpm == no
     enabled: false
 
+  - when: distro < rhel-9.8
+    enabled: false
+    because: Support has been addeed in RHEL-9.8 through RHEL-118148
+
 # As of now (Keylime tip of tree being e558fe3b425c6e79419ede5ecd8427ce06ef4dd6):
 # For attestation:
 # - ECC is supported with ECDSA

--- a/functional/tenant_api_version_negotiation/main.fmf
+++ b/functional/tenant_api_version_negotiation/main.fmf
@@ -1,0 +1,19 @@
+summary: Test tenant API version negotiation
+description: |
+    Verifies that tenant can negotiation API version individually
+    with the verifier, registrar and agent.
+    Also verify error handling when no common version is found.
+contact: Karel Srot <ksrot@redhat.com>
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+tag:
+  - CI-Tier-1
+require:
+  - yum
+recommend:
+  - keylime
+duration: 5m
+enabled: true
+id: d1fcaa1f-4b21-44af-b8ea-f6a4150b102f

--- a/functional/tenant_api_version_negotiation/test.sh
+++ b/functional/tenant_api_version_negotiation/test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+function set_api_versions() {
+    local current="$1"
+    local versions="$2"
+    local latest="$3"
+    local deprecated="$4"
+
+    sed -i "s/^CURRENT_VERSION.*/CURRENT_VERSION = \"$current\"/" "$SRCFILE"
+    sed -i "s/^VERSIONS.*/VERSIONS = $versions/" "$SRCFILE"
+    sed -i "s/^LATEST_VERSIONS.*/LATEST_VERSIONS = $latest/" "$SRCFILE"
+    sed -i "s/^DEPRECATED_VERSIONS.*/DEPRECATED_VERSIONS = $deprecated/" "$SRCFILE"
+
+    # print new configuration
+    grep -E '^(CURRENT_VERSION|VERSIONS|LATEST_VERSIONS|DEPRECATED_VERSIONS)' "$SRCFILE"
+}
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+        rlRun 'rlImport "./test-helpers"' || rlDie "cannot import keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+
+        # update /etc/keylime.conf
+        limeBackupConfig
+        limeEnableDebugLog
+        # verifier
+        rlRun "limeUpdateConf revocations enabled_revocation_notifications '[]'"
+        # tenant
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        # agent
+        rlRun "limeUpdateConf agent enable_revocation_notifications false"
+        # if TPM emulator is present
+        if limeTPMEmulated; then
+            # start tpm emulator
+            rlRun "limeStartTPMEmulator"
+            rlRun "limeWaitForTPMEmulator"
+            rlRun "limeCondStartAbrmd"
+            # start ima emulator
+            rlRun "limeInstallIMAConfig"
+            rlRun "limeStartIMAEmulator"
+        fi
+        sleep 5
+        # find source file where API versions are configured
+        SRCFILE=$( find /usr -wholename '*/keylime/api_version.py' )
+	rlFileBackup "$SRCFILE"
+        # configure and start verifier
+	rlRun "set_api_versions 2.1 '[\"2.0\", \"2.1\"]' '{\"2\": \"2.1\"}' '[]'"
+        rlRun "limeStartVerifier"
+        rlRun "limeWaitForVerifier"
+        # configure and start registrar, use different versions than verifier
+        rlRun "set_api_versions 2.3 '[\"2.2\", \"2.3\"]' '{\"2\": \"2.3\"}' '[]'"
+        rlRun "limeStartRegistrar"
+        rlRun "limeWaitForRegistrar"
+        # configure tenant, use one common (not current/latest) version with verifier and registrar
+        rlRun "set_api_versions 2.5 '[\"2.1\", \"2.3\", \"2.5\"]' '{\"2\": \"2.5\"}' '[]'"
+        # configure and start agent, use one common version with tenant
+        rlRun "limeUpdateConf agent api_versions '\"2.1, 2.2\"'"
+        rlRun "limeStartAgent"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test common API version negotiation with verifier and registrar"
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "Using API version 2.1 for verifier communication" "$rlRun_LOG"
+        rlAssertGrep "https://127.0.0.1:8881 .*GET /v2.1/agents" "$rlRun_LOG" -E
+        rlRun -s "keylime_tenant -c reglist"
+        rlAssertGrep "Using API version 2.3 for registrar communication" "$rlRun_LOG"
+        rlAssertGrep "https://127.0.0.1:8891 .*GET /v2.3/agents" "$rlRun_LOG" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test common API version negotiation with the agent"
+        rlRun "limeCreateTestPolicy"
+        rlRun -s "keylime_tenant -c add -u $AGENT_ID --verify --runtime-policy policy.json -f /etc/hostname"
+        rlAssertGrep "Using API version 2.1 for agent communication" "$rlRun_LOG"
+        rlAssertGrep "https://127.0.0.1:9002 .*GET /v2.1/keys/verify" "$rlRun_LOG" -E
+        rlRun -s "keylime_tenant -c delete -u $AGENT_ID"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test incorrect API version verifier and registrar"
+        # set API versions incompatible with verifier and registrar
+        rlRun "set_api_versions 2.4 '[\"2.4\"]' '{\"2\": \"2.4\"}' '[]'"
+        rlRun -s "keylime_tenant -c cvlist" 1
+        rlAssertNotGrep "Traceback" "$rlRun_LOG"
+        # TODO: add rlAssertGrep for some reasonable error message
+        rlRun -s "keylime_tenant -c reglist" 1
+        rlAssertNotGrep "Traceback" "$rlRun_LOG"
+        # TODO: add rlAssertGrep for some reasonable error message
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test incorrect API version for the agent"
+        # first check the agent since we need to be able to talk with verifier and registrar
+        rlRun "set_api_versions 2.3 '[\"2.0\", \"2.3\"]' '{\"2\": \"2.3\"}' '[]'"
+        rlRun -s "keylime_tenant -c add -u $AGENT_ID --verify --runtime-policy policy.json -f /etc/hostname" 1
+        rlAssertNotGrep "Traceback" "$rlRun_LOG"
+        rlAssertGrep "Agent.*has no compatible API" "$rlRun_LOG" -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        rlRun "limeStopAgent"
+        rlRun "limeStopRegistrar"
+        rlRun "limeStopVerifier"
+        if limeTPMEmulated; then
+            rlRun "limeStopIMAEmulator"
+            rlRun "limeStopTPMEmulator"
+            rlRun "limeCondStopAbrmd"
+        fi
+        limeSubmitCommonLogs
+        limeClearData
+	rlFileRestore
+        limeRestoreConfig
+    rlPhaseEnd
+
+rlJournalEnd


### PR DESCRIPTION
## Summary by Sourcery

Add helper utilities for configuring Keylime logging and add a new functional test covering tenant API version negotiation.

Enhancements:
- Extend configuration backup/restore helpers to include Keylime systemd drop-in directories and reload systemd when restored.
- Introduce helpers to enable and disable debug/trace logging for Keylime services, including Rust agents via systemd drop-ins.

Tests:
- Add a functional test that verifies tenant, verifier, registrar, and agent API version negotiation behavior under compatible and incompatible version configurations.