### PR TITLE
Add c10s prepare workaround for openssl version skew

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -38,14 +38,15 @@ adjust:
           - dnf config-manager --set-disabled epel || true
   - when: distro == rhel-10 or distro == centos-stream-10
     prepare+:
-      # Workaround: testing-farm-tag-repository may ship a stale openssl-devel
-      # that conflicts with a newer openssl-libs from baseos. Sync all openssl
-      # packages to the latest available version before any other dnf operation.
+      # Workaround: testing-farm-tag-repository may ship stale packages
+      # (e.g. openssl-devel, python3-devel) that conflict with newer
+      # versions from baseos. Lowering the repo priority ensures DNF
+      # prefers baseos/appstream/CRB versions during TMT package install.
       # Remove this block once the tag repo is fixed upstream.
       - how: shell
         order: 5
         script:
-          - dnf -y update --allowerasing openssl openssl-libs openssl-devel || true
+          - dnf config-manager --save --setopt=testing-farm-tag-repository.priority=999 2>/dev/null || true
       - how: shell
         order: 10
         script:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -38,6 +38,14 @@ adjust:
           - dnf config-manager --set-disabled epel || true
   - when: distro == rhel-10 or distro == centos-stream-10
     prepare+:
+      # Workaround: testing-farm-tag-repository may ship a stale openssl-devel
+      # that conflicts with a newer openssl-libs from baseos. Sync all openssl
+      # packages to the latest available version before any other dnf operation.
+      # Remove this block once the tag repo is fixed upstream.
+      - how: shell
+        order: 5
+        script:
+          - dnf -y update --allowerasing openssl openssl-libs openssl-devel || true
       - how: shell
         order: 10
         script:


### PR DESCRIPTION
The testing-farm-tag-repository can ship a stale openssl-devel that conflicts with a newer openssl-libs from the CentOS Stream 10 baseos repo, causing DNF dependency resolution to fail and aborting the entire prepare phase before any test runs.

Add an early prepare step (order 5) that syncs all openssl packages to the latest available version with --allowerasing, scoped only to RHEL-10 / CentOS Stream 10 via the existing adjust block. This runs before EPEL setup (order 10) and general package updates (order 30).

## Summary by Sourcery

Enhancements:
- Introduce an ordered prepare step to align OpenSSL-related packages and avoid DNF dependency resolution failures on RHEL 10 / CentOS Stream 10.