### PR TITLE
Disable test on RHEL-9.9 as well

### DIFF
--- a/compatibility/basic-attestation-on-localhost-api-version-bump/main.fmf
+++ b/compatibility/basic-attestation-on-localhost-api-version-bump/main.fmf
@@ -33,6 +33,6 @@ enabled: true
 id: a83ed2d4-7f54-4e83-bf3c-bee4868a7624
 
 adjust:
-  - when: distro == centos-stream-9 or distro <= rhel-9.8
+  - when: distro == centos-stream-9 or distro <= rhel-9.9
     enabled: false
     because: keylime agent supports only one API version


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update FMF metadata for the basic attestation on localhost API version bump compatibility test.