### PR TITLE
Give agent more time to start

### DIFF
--- a/functional/iak-idevid-register-with-certificates/main.fmf
+++ b/functional/iak-idevid-register-with-certificates/main.fmf
@@ -17,7 +17,7 @@ require:
 recommend:
   - keylime
   - tpm2-openssl
-duration: 5m
+duration: 8m
 enabled: true
 adjust:
   - when: distro < fedora-39 or distro = centos-stream-9

--- a/functional/iak-idevid-register-with-certificates/test.sh
+++ b/functional/iak-idevid-register-with-certificates/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
@@ -130,6 +129,9 @@ rlJournalStart
         rlRun "limeStartRegistrar"
         rlRun "limeWaitForRegistrar"
         rlRun "limeStartAgent"
+        # give agent more time to start as it is generating multiple RSA keys
+        # still we expect it to fail
+        rlRun "limeTIMEOUT=120 limeWaitForAgent" 1
         # Agent attempts to register and sends all the required information but the CA is not trusted
         # so registration fails at IDevID verification
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}" 1
@@ -142,6 +144,8 @@ rlJournalStart
         rlRun "mkdir -p $TPM_CERTS"
         rlRun "cp ./ca/certs/klca-chain.cert.pem $TPM_CERTS/"
         rlRun "limeStartAgent"
+        # give agent more time to start as it is generating multiple RSA keys
+        rlRun "limeTIMEOUT=120 limeWaitForAgent"
         # Agent can now register with IDevID and IAK getting verified
         rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
         rlAssertGrep "(IDevID created|Recreating IDevID)" "$(limeAgentLogfile)" -E


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Extend agent startup wait in the IAK/IDevID registration functional test to reduce flakiness when generating multiple RSA keys.