### PR TITLE
Avoid early "grep -q" termination

### DIFF
--- a/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
@@ -24,7 +24,9 @@ SWTPM_PID=""
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
+    # On some architectures (s390x), grep -q exits early after finding a match,
+    # therefore we rather redirect the output to /dev/null
+    if tpm2_getcap handles-persistent 2>&1 | grep "${persistent_handle}" > /dev/null; then
         return 0
     else
         return 1


### PR DESCRIPTION
Redirect whole grep output to /dev/null to avoid SIGPIPE issues due to an early 'grep -q' termination.

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent failures in TPM persistent handle detection by redirecting grep output to /dev/null instead of using quiet mode on platforms where grep -q may exit early.