### PR TITLE
Replace fixed sleep with rlWaitForCmd in agent-service-start test

### DIFF
--- a/sanity/agent-service-start/test.sh
+++ b/sanity/agent-service-start/test.sh
@@ -19,13 +19,12 @@ rlJournalStart
             rlRun "limeStartIMAEmulator"
         fi
         sleep 5
-        # start keylime_verifier
+        # start keylime_agent
 	# we expect it to fail because the registrar is missing
 	# but at least we check that it got to the point of
 	# contacting the registrar
         rlRun "limeStartAgent"
-	sleep 5
-	rlAssertGrep "Requesting registrar API version" "$(limeAgentLogfile)"
+	rlRun "rlWaitForCmd 'grep -q \"Requesting registrar API version\" \$(limeAgentLogfile)' -m 30 -d 1 -t 5"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"


### PR DESCRIPTION
On aarch64 hardware with real TPM, agent startup TPM operations can take 5+ seconds, causing a race condition with the fixed sleep 5. Use rlWaitForCmd to poll for the expected log message instead.

## Summary by Sourcery

Tests:
- Update the agent-service-start sanity test to wait for a specific agent log message using rlWaitForCmd instead of a fixed sleep, improving reliability on slower or real TPM hardware.