### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/setup/generate_upstream_rust_keylime_code_coverage/main.fmf
+++ b/setup/generate_upstream_rust_keylime_code_coverage/main.fmf
@@ -1,6 +1,9 @@
 summary: Process gathered code coverage data for the rust agent and generate a 
     report
-description:
+description: |
+    Verify that code coverage data collected during rust keylime agent
+    e2e tests can be processed using grcov and exported as HTML and
+    lcov reports for submission.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - keylime

--- a/upstream/run_keylime_tests/main.fmf
+++ b/upstream/run_keylime_tests/main.fmf
@@ -1,4 +1,8 @@
 summary: Run tests from keylime upstream testsuite
+description: |
+    Verify that the keylime upstream Python unit tests and functional
+    test scripts pass against the installed keylime package, optionally
+    collecting code coverage data.
 contact: Karel Srot <ksrot@redhat.com>
 component:
   - keylime

--- a/upstream/run_rust_keylime_tests/main.fmf
+++ b/upstream/run_rust_keylime_tests/main.fmf
@@ -1,5 +1,9 @@
-summary: Run tests from keylime rust upstream testsuite and eventually gather 
+summary: Run tests from keylime rust upstream testsuite and eventually gather
     code coverage
+description: |
+    Verify that the upstream rust keylime cargo tests pass with the
+    testing feature enabled, and optionally measure code coverage
+    using cargo-tarpaulin when KEYLIME_RUST_CODE_COVERAGE is set.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - keylime

--- a/upstream/run_tests_for_installed_keylime/main.fmf
+++ b/upstream/run_tests_for_installed_keylime/main.fmf
@@ -1,4 +1,8 @@
 summary: Run unit tests for installed keylime
+description: |
+    Verify that the upstream keylime unit tests pass when executed
+    against the RPM-installed or source-installed keylime package
+    using the upstream run_tests.sh harness.
 contact: Karel Srot <ksrot@redhat.com>
 component:
   - keylime


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Tests:
- Populate empty or missing description fields in main.fmf for upstream and installed Keylime test suites.