### PR TITLE
Added a tag to exclude the test from upstream CI

### DIFF
--- a/regression/cannot-use-mTLS-cert-on-server-admin-api-endpoint/main.fmf
+++ b/regression/cannot-use-mTLS-cert-on-server-admin-api-endpoint/main.fmf
@@ -16,6 +16,8 @@ component:
   - keylime
 test: ./test.sh
 framework: beakerlib
+tag:
+  - not-agent-upstream-CI
 require:
   - openssl
   - curl


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Mark the 'cannot-use-mTLS-cert-on-server-admin-api-endpoint' regression test to be excluded from upstream CI runs.