### PR TITLE
Adjust rlWaitForCmd timeout and unify the definiton of tpm_check_peristent_handle()

### DIFF
--- a/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
@@ -37,7 +37,9 @@ set -e
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
+    # On some architectures (s390x), grep -q exits early after finding a match,
+    # therefore we rather redirect the output to /dev/null
+    if tpm2_getcap handles-persistent 2>&1 | grep "${persistent_handle}" > /dev/null; then
         return 0
     else
         return 1

--- a/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
@@ -37,7 +37,7 @@ set -e
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_readpublic -c "${persistent_handle}" &>/dev/null; then
+    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
         return 0
     else
         return 1

--- a/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/setup_test_agent.sh
@@ -37,7 +37,7 @@ set -e
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
+    if tpm2_readpublic -c "${persistent_handle}" &>/dev/null; then
         return 0
     else
         return 1

--- a/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
@@ -24,9 +24,7 @@ SWTPM_PID=""
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    # On some architectures (s390x), grep -q exits early after finding a match,
-    # therefore we rather redirect the output to /dev/null
-    if tpm2_getcap handles-persistent 2>&1 | grep "${persistent_handle}" > /dev/null; then
+    if tpm2_readpublic -c "${persistent_handle}" &>/dev/null; then
         return 0
     else
         return 1

--- a/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
@@ -24,7 +24,9 @@ SWTPM_PID=""
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
+    # On some architectures (s390x), grep -q exits early after finding a match,
+    # therefore we rather redirect the output to /dev/null
+    if tpm2_getcap handles-persistent 2>&1 | grep "${persistent_handle}" > /dev/null; then
         return 0
     else
         return 1

--- a/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
+++ b/functional/push-authentication-cross-agent-attestation/custom-agent/test_tpm_helpers.sh
@@ -24,7 +24,7 @@ SWTPM_PID=""
 tpm_check_persistent_handle() {
     local persistent_handle="${1}"
 
-    if tpm2_readpublic -c "${persistent_handle}" &>/dev/null; then
+    if tpm2_getcap handles-persistent 2>&1 | grep -q "${persistent_handle}"; then
         return 0
     else
         return 1

--- a/sanity/agent-service-start/test.sh
+++ b/sanity/agent-service-start/test.sh
@@ -24,7 +24,7 @@ rlJournalStart
 	# but at least we check that it got to the point of
 	# contacting the registrar
         rlRun "limeStartAgent"
-	rlRun "rlWaitForCmd 'grep -q \"Requesting registrar API version\" \$(limeAgentLogfile)' -m 30 -d 1 -t 5"
+	rlRun "rlWaitForCmd 'grep -q \"Requesting registrar API version\" \$(limeAgentLogfile)' -m ${limeTIMEOUT} -d 1 -t ${limeTIMEOUT}"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"

--- a/sanity/agent-service-start/test.sh
+++ b/sanity/agent-service-start/test.sh
@@ -24,7 +24,7 @@ rlJournalStart
 	# but at least we check that it got to the point of
 	# contacting the registrar
         rlRun "limeStartAgent"
-	rlRun "rlWaitForCmd 'grep -q \"Requesting registrar API version\" \$(limeAgentLogfile)' -m ${limeTIMEOUT} -d 1 -t ${limeTIMEOUT}"
+	rlRun "rlWaitForCmd 'grep -q \"Requesting registrar API version\" \$(limeAgentLogfile)' -m 30 -d 1 -t ${limeTIMEOUT}"
         if limeTPMEmulated; then
             rlRun "limeStopIMAEmulator"
             rlRun "limeStopTPMEmulator"


### PR DESCRIPTION
- Updated the fix of ambiguity on the s390x "tpm2_getcap ... | grep ..."   in the other script as well
-  Increased test timeout  in agent-service-start test:  HW TPM startup on aarch64 required 1s extra to pass as the scenario proceeded as expected
