### PR TITLE
Expect TIMEOUT instead of FAIL for stopped PUSH agent (#1060)

### DIFF
--- a/functional/agent-resilience-and-reattestation/test.sh
+++ b/functional/agent-resilience-and-reattestation/test.sh
@@ -175,14 +175,22 @@ function check_time_diffs() {
         rlRun -s "keylime_tenant -c cvlist"
     rlPhaseEnd
 
-    rlPhaseStartTest "Stop agent so it stops sending quotes - should fail attestation"
+    if [ "${AGENT_SERVICE}" == "PushAgent" ]; then
+        EXPECTED_STATUS="TIMEOUT"
+        EXPECTED_LABEL="timeout"
+    else
+        EXPECTED_STATUS="(Failed|Invalid Quote)"
+        EXPECTED_LABEL="fail"
+    fi
+
+    rlPhaseStartTest "Stop agent so it stops sending quotes - should ${EXPECTED_LABEL} attestation"
         rlLogInfo "Stopping agent"
         rlRun "limeStop${AGENT_SERVICE}"
         # verify the agent is not attested
         if [ "${AGENT_SERVICE}" == "PushAgent" ]; then
-            rlRun "limeTIMEOUT=$(( ${ATTESTATION_INTERVAL}*6 )) limeWaitForAgentStatus --field attestation_status '$AGENT_ID' 'FAIL'" 0 "Agent should fail attestation"
+            rlRun "limeTIMEOUT=$(( ATTESTATION_INTERVAL*6 )) limeWaitForAgentStatus --field attestation_status '$AGENT_ID' '${EXPECTED_STATUS}'" 0 "Agent should ${EXPECTED_LABEL} attestation"
         else
-            rlRun "limeTIMEOUT=$(( ${ATTESTATION_INTERVAL}*6 )) limeWaitForAgentStatus '$AGENT_ID' '(Failed|Invalid Quote)'" 0 "Agent should fail attestation"
+            rlRun "limeTIMEOUT=$(( ATTESTATION_INTERVAL*6 )) limeWaitForAgentStatus '$AGENT_ID' '${EXPECTED_STATUS}'" 0 "Agent should ${EXPECTED_LABEL} attestation"
         fi
         rlRun -s "keylime_tenant -c cvlist"
     rlPhaseEnd


### PR DESCRIPTION
Upstream keylime commit 982a86b changed process_get_status() to return "TIMEOUT" instead of "FAIL" when a PUSH mode agent stops sending quotes. Update the agent-resilience-and-reattestation test to match the new upstream behavior.

Extract expected status and label into variables so the phase title and assertion messages accurately reflect each agent mode and future status changes are easier to maintain.

## Summary by Sourcery

Align agent resilience and reattestation functional test expectations with updated attestation status behavior for stopped agents.

Bug Fixes:
- Update PUSH mode agent attestation check to expect TIMEOUT instead of FAIL when quotes stop.

Enhancements:
- Generalize attestation status and label handling in the test via variables to support different agent modes and future status changes.

Tests:
- Adjust functional test phase titles and assertions to reflect mode-specific attestation outcomes using shared status/label variables.