### PR TITLE
Fix SELinux module definition

### DIFF
--- a/setup/configure_tpm_emulator/swtpm_permissive.te
+++ b/setup/configure_tpm_emulator/swtpm_permissive.te
@@ -1,15 +1,18 @@
 policy_module(swtpm_permissive, 1.0)
-require {
+
 type swtpm_t;
 type swtpm_exec_t;
+
+require {
 type unreserved_port_t;
 type var_lib_t;
 type init_t;
 type device_t;
 }
-permissive swtpm_t;
 
 init_daemon_domain(swtpm_t, swtpm_exec_t);
+
+permissive swtpm_t;
 
 dontaudit swtpm_t self:tcp_socket { accept listen };
 dontaudit swtpm_t swtpm_t:capability { sys_admin };


### PR DESCRIPTION
On Rawhide loading of compiled module started to fail with:
  #semodule -i swtpm_permissive.pp'
  Failed to resolve typeattributeset statement at /var/lib/selinux/targeted/tmp/modules/400/swtpm_permissive/cil:2
  Failed to resolve AST
  semodule:  Failed!

## Summary by Sourcery

Bug Fixes:
- Resolve SELinux module definition issues that caused semodule installation of swtpm_permissive.pp to fail on Rawhide.