### PR TITLE
Update ALL kernels in IMA configuration setup

### DIFF
--- a/setup/configure_kernel_ima_module/test.sh
+++ b/setup/configure_kernel_ima_module/test.sh
@@ -44,8 +44,10 @@ rlJournalStart
         rlRun "cat /proc/cmdline"
         rlRun "grubby --info ALL"
         rlRun "grubby --default-index"
-        rlRun "grubby --update-kernel DEFAULT --args 'ima_appraise=${IMA_APPRAISE} ima_canonical_fmt ima_template=${IMA_TEMPLATE}'"
-        rlRun -s "grubby --info DEFAULT | grep '^args'"
+        # Ensure IMA args apply to whichever kernel actually reboots (not only DEFAULT)
+        rlRun "grubby --update-kernel ALL --args 'ima_appraise=${IMA_APPRAISE} ima_canonical_fmt ima_template=${IMA_TEMPLATE}'"
+        rlRun -s "grubby --info \"/boot/vmlinuz-$(uname -r)\" | grep '^args'"
+        # Verify IMA args apply to the actual kernel that will boot
         rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
         rlAssertGrep "ima_canonical_fmt" $rlRun_LOG
         rlAssertGrep "ima_template=${IMA_TEMPLATE}" $rlRun_LOG


### PR DESCRIPTION
On s390x, zipl may boot the running (+debug) kernel while grubby DEFAULT points elsewhere. Updating only DEFAULT leaves the booted entry without IMA cmdline args.
Using ALL ensures IMA args apply to whichever kernel actually reboots (not only DEFAULT).

See: https://artifacts.osci.redhat.com/testing-farm/2625a6de-4896-4b57-acf6-e1ef087372b4/

## Summary by Sourcery

Tests:
- Adjust kernel IMA configuration test to update all grubby kernels and verify arguments against the currently running kernel image.