### PR TITLE
Update ALL kernels in IMA configuration setup

### DIFF
--- a/setup/configure_kernel_ima_module/test.sh
+++ b/setup/configure_kernel_ima_module/test.sh
@@ -44,8 +44,10 @@ rlJournalStart
         rlRun "cat /proc/cmdline"
         rlRun "grubby --info ALL"
         rlRun "grubby --default-index"
-        rlRun "grubby --update-kernel DEFAULT --args 'ima_appraise=${IMA_APPRAISE} ima_canonical_fmt ima_template=${IMA_TEMPLATE}'"
-        rlRun -s "grubby --info DEFAULT | grep '^args'"
+        # Ensure IMA args apply to whichever kernel actually reboots (not only DEFAULT)
+        rlRun "grubby --update-kernel ALL --args 'ima_appraise=${IMA_APPRAISE} ima_canonical_fmt ima_template=${IMA_TEMPLATE}'"
+        rlRun -s "grubby --info \"/boot/vmlinuz-$(uname -r)\" | grep '^args'"
+        # Verify IMA args apply to the actual kernel that will boot
         rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
         rlAssertGrep "ima_canonical_fmt" $rlRun_LOG
         rlAssertGrep "ima_template=${IMA_TEMPLATE}" $rlRun_LOG


### PR DESCRIPTION
On s390x, zipl may boot the running (+debug) kernel while grubby DEFAULT points elsewhere. Updating only DEFAULT leaves the booted entry without IMA cmdline args.
Using ALL ensures IMA args apply to whichever kernel actually reboots (not only DEFAULT).

See failure example [here](https://reportportal-rhel.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#baseosqe/launches/all/2a1aef40-4e38-4845-9818-46bf7b5fb7c9): https://artifacts.osci.redhat.com/testing-farm/2625a6de-4896-4b57-acf6-e1ef087372b4/

## Summary by Sourcery

Ensure IMA kernel command-line arguments are applied to all bootable kernels rather than only the default, and verify they are present on the currently running kernel.

Enhancements:
- Update the IMA configuration test to use grubby --update-kernel ALL so IMA arguments are set for every kernel entry.
- Adjust test verification to check IMA arguments on the actually running kernel image instead of the grubby DEFAULT entry.