### PR TITLE
Use limeTIMEOUT as default in __limeWaitForProcessEnd()

### DIFF
--- a/Library/test-helpers/lib.sh
+++ b/Library/test-helpers/lib.sh
@@ -607,7 +607,7 @@ __limeStillRunning() {
 
 __limeWaitForProcessEnd() {
     local NAME=$1
-    local TIMEOUT=10
+    local TIMEOUT="${limeTIMEOUT}"
     local RET=1
 
     [ -n "$2" ] && TIMEOUT=$2


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Align process wait helper timeout with the configurable limeTIMEOUT setting instead of a fixed 10-second default.