### PR TITLE
Exclude push+PostgreSQL regression from agent upstream CI

### DIFF
--- a/functional/push-model-attestation-with-postgresql-db/main.fmf
+++ b/functional/push-model-attestation-with-postgresql-db/main.fmf
@@ -11,6 +11,8 @@ component:
   - keylime
 test: ./test.sh
 framework: beakerlib
+tag:
+  - not-agent-upstream-CI
 require:
   - yum
   - postgresql-server


### PR DESCRIPTION
The test covers verifier/registrar PostgreSQL schema behavior, not agent functionality, so it should not be required in rust-keylime CI parity.

## Summary by Sourcery

Tests:
- Adjust functional test configuration to stop running the PostgreSQL push-model attestation regression test in the agent upstream CI.